### PR TITLE
Tweak Select component to allow blocks

### DIFF
--- a/addon/components/mxa/select.hbs
+++ b/addon/components/mxa/select.hbs
@@ -1,23 +1,41 @@
 <div>
   <div class="mt-1 relative">
-    <button type="button" aria-haspopup="listbox" aria-expanded="true" aria-labelledby="listbox-label" class="relative w-full {{if @isDisabled 'bg-frost-100' 'bg-white'}} border border-frost-100 rounded shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-plum-100 focus:border-plum-100 sm:text-sm"
-       {{on 'click' this.toggleOptions}}
-       data-test-select-button
-       ...attributes
+    <button
+      type="button"
+      aria-haspopup="listbox"
+      aria-expanded="true"
+      aria-labelledby="listbox-label"
+      class="relative w-full
+        {{if @isDisabled 'bg-frost-100' 'bg-white'}}
+         border border-frost-100 rounded shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-plum-100 focus:border-plum-100 sm:text-sm"
+      data-test-select-button
+      ...attributes
+      {{on 'click' this.toggleOptions}}
     >
       <span class="flex items-center">
         <span class="ml-1 block truncate" data-test-select-display-selected>
           {{this.selectedOptionName}}
         </span>
       </span>
-      <span class="ml-3 absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+      <span
+        class="ml-3 absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none"
+      >
         <!-- Heroicon name: selector -->
-        <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fill-rule="evenodd" d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
+        <svg
+          class="h-5 w-5 text-gray-400"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
+            clip-rule="evenodd"
+          ></path>
         </svg>
       </span>
     </button>
-
     <!--
       Select popover, show/hide based on select state.
 
@@ -29,19 +47,34 @@
         To: "opacity-0"
     -->
     {{#if this.isShowingOptions}}
-      <div class="absolute mt-1 w-full rounded-md bg-white shadow-lg z-10"
-        {{on-click-outside (fn (mut this.isShowingOptions) false) 'document'}}
+      <div
+        class="absolute mt-1 w-full rounded-md bg-white shadow-lg z-10"
+        {{on-click-outside
+          (fn (mut this.isShowingOptions) false)
+          'document'
+          capture=true
+        }}
       >
-        <ul tabindex="-1" role="listbox" aria-labelledby="listbox-label" aria-activedescendant="listbox-item-3" class="max-h-56 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm">
-          {{#each @options as |option|}}
-            <Mxa::Select::Option
-              @option={{option}}
-              @selectedOption={{@selectedOption}}
-              @setSelectedOption={{this.setSelectedOption}}
-              @optionNameKey={{this.optionNameKey}}
-              @optionValueKey={{this.optionValueKey}}
-            />
-          {{/each}}
+        <ul
+          tabindex="-1"
+          role="listbox"
+          aria-labelledby="listbox-label"
+          aria-activedescendant="listbox-item-3"
+          class="max-h-56 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm"
+        >
+          {{#if (has-block)}}
+            {{yield this.setSelectedOption}}
+          {{else}}
+            {{#each @options as |option|}}
+              <Mxa::Select::Option
+                @option={{option}}
+                @selectedOption={{@selectedOption}}
+                @setSelectedOption={{this.setSelectedOption}}
+                @optionNameKey={{this.optionNameKey}}
+                @optionValueKey={{this.optionValueKey}}
+              />
+            {{/each}}
+          {{/if}}
           <!--
             Select option, manage highlight styles based on mouseenter/mouseleave and keyboard navigation.
 

--- a/addon/components/mxa/select.js
+++ b/addon/components/mxa/select.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action, get } from "@ember/object";
+import { action, get } from '@ember/object';
 
 export default class MxaSelectComponent extends Component {
   @tracked
@@ -21,9 +21,10 @@ export default class MxaSelectComponent extends Component {
 
   @action
   toggleOptions(event) {
-    if (this.args.isDisabled) { return; }
+    if (this.args.isDisabled) {
+      return;
+    }
     this.isShowingOptions = !this.isShowingOptions;
-    event.stopPropagation();
   }
 
   @action

--- a/addon/components/mxa/select/option.hbs
+++ b/addon/components/mxa/select/option.hbs
@@ -1,6 +1,11 @@
 <li id="listbox-item-0" role="option" class="text-gray-900 cursor-default select-none relative py-2 pl-3 pr-9" data-test-select-option>
   <div class="flex items-center" {{on 'click' (fn @setSelectedOption @option)}} data-test-select-option-button={{this.optionName}}>
     <!-- Selected: "font-semibold", Not Selected: "font-normal" -->
+
+    {{#if (has-block)}}
+      {{yield}}
+    {{/if}}
+
     <span class="ml-1 block font-normal truncate">
       {{this.optionName}}
     </span>

--- a/addon/modifiers/on-click-outside.js
+++ b/addon/modifiers/on-click-outside.js
@@ -1,23 +1,24 @@
 import { modifier } from 'ember-modifier';
 
-export default modifier((element, [callback, outsideElementSelector]) => {
-  function handleClick(event) {
-    if (!element.contains(event.target)) {
-      callback(event);
+export default modifier((element, [callback, outsideElementSelector], options) => {
+    function handleClick(event) {
+      if (!element.contains(event.target)) {
+        callback(event);
+      }
     }
+
+    let outsideElement;
+
+    if (outsideElementSelector === 'document') {
+      outsideElement = document;
+    } else {
+      outsideElement = document.querySelector(outsideElementSelector);
+    }
+
+    outsideElement.addEventListener('click', handleClick, options);
+
+    return () => {
+      outsideElement.removeEventListener('click', handleClick, options);
+    };
   }
-
-  let outsideElement;
-
-  if (outsideElementSelector === 'document') {
-    outsideElement = document;
-  } else {
-    outsideElement = document.querySelector(outsideElementSelector);
-  }
-
-  outsideElement.addEventListener('click', handleClick);
-
-  return () => {
-    outsideElement.removeEventListener('click', handleClick);
-  };
-});
+);


### PR DESCRIPTION
+ Let our Select component accept HTML blocks

+ Refactor how on click outside works. This still isnt perfect interaction wise, but is better than what currently exists. This will require some more polish

Eventually we should refactor this to named components after we upgrade our ember versions across the UIs and this addon. This will allows us to really customize what we can do with the Select component, and add custom HTML content essentially anywhere.