### PR TITLE
ops(github): sync main branch with changes on source repo

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,24 @@
+name: GitHub Repo Sync from Mx
+
+on:
+  repository_dispatch:
+    types: [sync-mx-to-conduit]
+
+jobs:
+  sync-conduit-io:
+    name: Sync to ConduitIO
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Runs the Super-Linter action
+      - name: Run Sync
+        uses: repo-sync/github-sync@v2.3.0
+        with:
+          source_repo: "https://${{ secrets.PAT }}@github.com/meroxa/mx-ui-components.git"
+          source_branch: "main"
+          destination_branch: "main"
+          github_token: ${{ secrets.PAT }}


### PR DESCRIPTION
This should allow an automatic sync of the main branch anytime the source repository's main branch is updated.


### Test Run

See https://github.com/ConduitIO/mx-ui-components/runs/2271856211

### References

Github Repo Sync: https://github.com/marketplace/actions/github-repo-sync
Github Actions Quickstart: https://docs.github.com/en/actions/quickstart