### PR TITLE
Fix npm package version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,8 @@
       "release": true,
       "releaseName": "v${version}"
     },
-    "npm": false
+    "npm": {
+      "publish": false
+    }
   }
 }


### PR DESCRIPTION
the `npm` property controls package bumps, but we dont wan't it to publish, so we instead just null out the publish option instead of the whole object. 