### PR TITLE
feat(mox/list): add sorting functionality to table elements

### DIFF
--- a/addon/components/mox/icon.js
+++ b/addon/components/mox/icon.js
@@ -6,6 +6,14 @@ export default class MoxIconComponent extends Component {
       return 'h-8 w-8';
     }
 
+    if (this.args.size === 'small') {
+      return 'h-4 w-4';
+    }
+
+    if (this.args.size === 'x-small') {
+      return 'h-2.5 w-2.5';
+    }
+
     return 'h-6 w-6';
   }
 }

--- a/addon/components/mox/list.hbs
+++ b/addon/components/mox/list.hbs
@@ -1,10 +1,10 @@
 <div data-test-mox-list ...attributes>
   <table class="table-auto w-full text-left">
     <Mox::List::Header>
-      {{yield to="header"}}
+      {{yield (hash sortByColumn=this.sortByColumn sortedBy=this.sortedBy) to="header"}}
     </Mox::List::Header>
     <Mox::List::Body>
-      {{yield to="body"}}
+      {{yield this.sortedItems to="body"}}
     </Mox::List::Body>
   </table>
 </div>

--- a/addon/components/mox/list.js
+++ b/addon/components/mox/list.js
@@ -1,0 +1,33 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { sort } from '@ember/object/computed';
+import { tracked } from '@glimmer/tracking';
+
+export default class MoxListComponent extends Component {
+  @tracked
+  items;
+
+  @tracked
+  sortedBy;
+
+  @tracked
+  sortDirection;
+
+  constructor() {
+    super(...arguments);
+    this.items = this.args.items;
+  }
+
+  @sort('items', 'sortSetting') sortedItems;
+
+  get sortSetting() {
+    return [`${this.sortedBy}:${this.sortDirection}`];
+  }
+
+  @action
+  sortByColumn(attr, sortDirection, ev) {
+    console.log({ message: 'sorted...', attr, sortDirection });
+    this.sortedBy = attr;
+    this.sortDirection = sortDirection;
+  }
+}

--- a/addon/components/mox/list.js
+++ b/addon/components/mox/list.js
@@ -25,8 +25,7 @@ export default class MoxListComponent extends Component {
   }
 
   @action
-  sortByColumn(attr, sortDirection, ev) {
-    console.log({ message: 'sorted...', attr, sortDirection });
+  sortByColumn(attr, sortDirection) {
     this.sortedBy = attr;
     this.sortDirection = sortDirection;
   }

--- a/addon/components/mox/list/header.hbs
+++ b/addon/components/mox/list/header.hbs
@@ -1,5 +1,5 @@
 <thead data-test-mox-list-header ...attributes>
-  <tr class="border-b border-gray-700 text-gray-300">
+  <tr class="border-b border-gray-700 text-gray-300 align-middle">
     {{yield}}
   </tr>
 </thead>

--- a/addon/components/mox/list/item.hbs
+++ b/addon/components/mox/list/item.hbs
@@ -1,15 +1,15 @@
 {{#unless @isDisabled}}
   {{#if @isHeader}}
     <th class="text-xs uppercase py-3 px-4  align-middle relative" data-test-mox-list-header-item ...attributes>
-      <div class="inline-block mt-auto py-0.5 {{if @isActive "text-white font-semibold" "text-gray-300 font-medium"}}">
+      <div class="inline-block mt-auto py-0.5 {{if @isActive "text-white font-semibold" "text-gray-300 font-medium"}}" data-test-mox-list-header-item-label>
         {{yield}}
       </div>
       {{#if @sort}}
         <div class="inline-block mt-0 mx-2 absolute">
-          <button class="block hover:text-cyan-500 focus:text-cyan-500 {{if @isActive "text-gray-500"}}" type="button" {{on "click" (fn @sort "asc")}}>
+          <button class="block hover:text-cyan-500 focus:text-cyan-500 {{if @isActive "text-gray-500"}}" type="button" {{on "click" (fn @sort "asc")}} data-test-mox-list-header-sort-asc>
             <Mox::Icon @iconName="chevron-down-24" class="transition rotate-180" @size="x-small" />
           </button>
-          <button class="block hover:text-cyan-500 focus:text-cyan-500 {{if @isActive "text-gray-500"}}" type="button" {{on "click" (fn @sort "desc")}}>
+          <button class="block hover:text-cyan-500 focus:text-cyan-500 {{if @isActive "text-gray-500"}}" type="button" {{on "click" (fn @sort "desc")}} data-test-mox-list-header-sort-desc>
             <Mox::Icon @iconName="chevron-down-24" class="transition" @size="x-small" />
           </button>
         </div>

--- a/addon/components/mox/list/item.hbs
+++ b/addon/components/mox/list/item.hbs
@@ -1,7 +1,19 @@
 {{#unless @isDisabled}}
   {{#if @isHeader}}
-    <th class="text-xs uppercase font-medium py-3 px-4 text-gray-300" data-test-mox-list-header-item ...attributes>
-      {{yield}}
+    <th class="text-xs uppercase py-3 px-4  align-middle relative" data-test-mox-list-header-item ...attributes>
+      <div class="inline-block mt-auto py-0.5 {{if @isActive "text-white font-semibold" "text-gray-300 font-medium"}}">
+        {{yield}}
+      </div>
+      {{#if @sort}}
+        <div class="inline-block mt-0 mx-2 absolute">
+          <button class="block hover:text-cyan-500 focus:text-cyan-500 {{if @isActive "text-gray-500"}}" type="button" {{on "click" (fn @sort "asc")}}>
+            <Mox::Icon @iconName="chevron-down-24" class="transition rotate-180" @size="x-small" />
+          </button>
+          <button class="block hover:text-cyan-500 focus:text-cyan-500 {{if @isActive "text-gray-500"}}" type="button" {{on "click" (fn @sort "desc")}}>
+            <Mox::Icon @iconName="chevron-down-24" class="transition" @size="x-small" />
+          </button>
+        </div>
+      {{/if}}
     </th>
   {{else}}
     {{#if @route}}

--- a/stories/mox-icon.stories.js
+++ b/stories/mox-icon.stories.js
@@ -32,6 +32,8 @@ const Template = (args) => ({
 
 export const Default = Template.bind({});
 export const Large = Template.bind({});
+export const Small = Template.bind({});
+export const XSmall = Template.bind({});
 
 Default.args = {
   allOptions: colorOptions,
@@ -42,4 +44,16 @@ Large.args = {
   allOptions: colorOptions,
   color: 'text-gray-300',
   size: 'large',
+};
+
+Small.args = {
+  allOptions: colorOptions,
+  color: 'text-gray-300',
+  size: 'small',
+};
+
+XSmall.args = {
+  allOptions: colorOptions,
+  color: 'text-gray-300',
+  size: 'x-small',
 };

--- a/stories/mox-list.stories.js
+++ b/stories/mox-list.stories.js
@@ -61,4 +61,54 @@ const Template = (args) => ({
   context: args,
 });
 
+const SortableTemplate = (args) => ({
+  template: hbs`
+  <Mox::List @items={{this.listItems}}>
+    <:header as |s|>
+      {{log (eq s.sortedBy "name")}}
+      <Mox::List::Item @isHeader={{true}} @isActive={{eq s.sortedBy "name"}} @sort={{fn s.sortByColumn "name"}}>
+        Name
+      </Mox::List::Item>
+      <Mox::List::Item @isHeader={{true}} @isActive={{eq s.sortedBy "description"}} @sort={{fn s.sortByColumn "description"}}>
+        Description
+      </Mox::List::Item>
+      <Mox::List::Item @isHeader={{true}} @isActive={{eq s.sortedBy "damage"}} @sort={{fn s.sortByColumn "damage"}}>
+        Damage / Recovery
+      </Mox::List::Item>
+      <Mox::List::Item @isHeader={{true}} @isActive={{eq s.sortedBy "price"}} @sort={{fn s.sortByColumn "price"}}>
+        Price
+      </Mox::List::Item>
+    </:header>
+    <:body as |sortedItems|>
+      {{#each sortedItems as |item|}}
+        <Mox::List::Row>
+          <Mox::List::Item>
+            {{item.name}}
+          </Mox::List::Item>
+          <Mox::List::Item>
+            {{item.description}}
+          </Mox::List::Item>
+          <Mox::List::Item>
+            {{item.damage}}
+          </Mox::List::Item>
+          <Mox::List::Item>
+            {{item.price}}
+          </Mox::List::Item>
+        </Mox::List::Row>
+      {{/each}}
+    </:body>
+  </Mox::List>
+`,
+  context: args,
+});
+
 export const Default = Template.bind({});
+export const Sortable = SortableTemplate.bind({});
+Sortable.args = {
+  listItems: [
+    { name: 'Lunar Curtain', description: 'Casts [MBarrier] on the party.', damage: 0, price: 0 },
+    { name: 'Fire Veil', description: 'Uses "Fire3" on all opponents', damage: 1200, price: 800 },
+    { name: 'Stardust', description: 'Uses "Comet2" on all opponents', damage: 1120, price: 8000 },
+    { name: 'Hi-Potion', description: 'Restores HP by 500', damage: 500, price: 300 },
+  ],
+};

--- a/stories/mox-list.stories.js
+++ b/stories/mox-list.stories.js
@@ -65,7 +65,6 @@ const SortableTemplate = (args) => ({
   template: hbs`
   <Mox::List @items={{this.listItems}}>
     <:header as |s|>
-      {{log (eq s.sortedBy "name")}}
       <Mox::List::Item @isHeader={{true}} @isActive={{eq s.sortedBy "name"}} @sort={{fn s.sortByColumn "name"}}>
         Name
       </Mox::List::Item>

--- a/tests/dummy/public/svg-defs.svg
+++ b/tests/dummy/public/svg-defs.svg
@@ -123,11 +123,11 @@
       <path d="M3.33325 10H2.66659C2.31296 10 1.97382 9.85953 1.72378 9.60948C1.47373 9.35943 1.33325 9.02029 1.33325 8.66667V2.66667C1.33325 2.31305 1.47373 1.97391 1.72378 1.72386C1.97382 1.47381 2.31296 1.33334 2.66659 1.33334H8.66659C9.02021 1.33334 9.35935 1.47381 9.60939 1.72386C9.85944 1.97391 9.99992 2.31305 9.99992 2.66667V3.33334" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </symbol>
 
-    <symbol id="chevron-down-24" width="24" height="24" fill="none">
+    <symbol id="chevron-down-24" viewBox="0 0 24 24" fill="none">
       <path d="M19 9L12 16L5 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </symbol>
 
-    <symbol id="chevron-right-24" width="24" height="24" fill="none">
+    <symbol id="chevron-right-24" viewBox="0 0 24 24" fill="none">
       <path d="M9 18L15 12L9 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </symbol>
 

--- a/tests/integration/components/mox/icon-test.js
+++ b/tests/integration/components/mox/icon-test.js
@@ -27,6 +27,20 @@ module('Integration | Component | mox/icon', function(hooks) {
     assert.dom('[data-test-mox-icon="connectors-16"]').hasClass('w-8');
   });
 
+  test('it renders a small variant of the icon', async function(assert) {
+    await render(hbs`<Mox::Icon @iconName="connectors-16" @size="small" />`);
+
+    assert.dom('[data-test-mox-icon="connectors-16"]').hasClass('h-4');
+    assert.dom('[data-test-mox-icon="connectors-16"]').hasClass('w-4');
+  });
+
+  test('it renders an extra small variant of the icon', async function(assert) {
+    await render(hbs`<Mox::Icon @iconName="connectors-16" @size="x-small" />`);
+
+    assert.dom('[data-test-mox-icon="connectors-16"]').hasClass('h-2.5');
+    assert.dom('[data-test-mox-icon="connectors-16"]').hasClass('w-2.5');
+  });
+
   test('it renders with currentFill and currentStroke by default', async function(assert) {
     await render(hbs`<Mox::Icon @iconName="connectors-16" />`);
 

--- a/tests/integration/components/mox/list-test.js
+++ b/tests/integration/components/mox/list-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, findAll, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 
@@ -48,5 +48,125 @@ module('Integration | Component | mox/list', function(hooks) {
 
     await a11yAudit();
     assert.ok(true, 'no a11y detected');
+  });
+
+  module('sortable list', function(hooks) {
+    hooks.beforeEach(async function() {
+      this.listItems = [
+        { name: 'Lunar Curtain', description: 'Casts [MBarrier] on the party.', id: 1, price: 1 },
+        { name: 'Fire Veil', description: 'Uses "Fire3" on all opponents', id: 2, price: 800 },
+        { name: 'Stardust', description: 'Uses "Comet2" on all opponents', id: 3, price: 8000 },
+        { name: 'Hi-Potion', description: 'Restores HP by 500', id: 4, price: 0 },
+      ];
+
+      await render(
+        hbs`
+        <Mox::List @items={{this.listItems}}>
+          <:header as |s|>
+            <Mox::List::Item @isHeader={{true}} @isActive={{eq s.sortedBy "name"}} @sort={{fn s.sortByColumn "name"}} data-test-name>
+              Name
+            </Mox::List::Item>
+            <Mox::List::Item @isHeader={{true}} @isActive={{eq s.sortedBy "description"}} @sort={{fn s.sortByColumn "description"}} data-test-description>
+              Description
+            </Mox::List::Item>
+            <Mox::List::Item @isHeader={{true}} @isActive={{eq s.sortedBy "damage"}} @sort={{fn s.sortByColumn "id"}} data-test-id>
+              ID
+            </Mox::List::Item>
+            <Mox::List::Item @isHeader={{true}} @isActive={{eq s.sortedBy "price"}} @sort={{fn s.sortByColumn "price"}} data-test-price>
+              Price
+            </Mox::List::Item>
+          </:header>
+          <:body as |sortedItems|>
+            {{#each sortedItems as |item|}}
+              <Mox::List::Row>
+                <Mox::List::Item>
+                  {{item.name}}
+                </Mox::List::Item>
+                <Mox::List::Item>
+                  {{item.description}}
+                </Mox::List::Item>
+                <Mox::List::Item>
+                  {{item.id}}
+                </Mox::List::Item>
+                <Mox::List::Item>
+                  {{item.price}}
+                </Mox::List::Item>
+              </Mox::List::Row>
+            {{/each}}
+          </:body>
+        </Mox::List>
+      `);
+    });
+
+    test('it renders', function (assert) {
+      assert.dom('[data-test-mox-list-header]').includesText('Name');
+      assert.dom('[data-test-mox-list-header]').includesText('Description');
+      assert.dom('[data-test-mox-list-header]').includesText('ID');
+      assert.dom('[data-test-mox-list-header]').includesText('Price');
+      assert.dom('[data-test-mox-list-body]').includesText('Lunar Curtain');
+      assert.dom('[data-test-mox-list-body]').includesText('Casts [MBarrier] on the party.');
+      assert.dom('[data-test-mox-list-body]').includesText('1');
+      assert.dom('[data-test-mox-list-body]').includesText('0');
+      assert.dom('[data-test-mox-list-row]').exists({ count: 4 });
+    });
+
+    test('it renders the active state for the currently selected column', async function (assert) {
+      // precondition: none of the header columns are marked as active by default
+      assert.dom('[data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').doesNotHaveClass('text-white');
+      assert.dom('[data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').doesNotHaveClass('font-semibold');
+
+      assert.dom('[data-test-name][data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').doesNotHaveClass('text-white');
+      assert.dom('[data-test-name][data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').doesNotHaveClass('font-semibold');
+
+      await click('[data-test-name] [data-test-mox-list-header-sort-desc]');
+
+      // it only marks the name column as active
+      assert.dom('[data-test-name][data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').hasClass('text-white');
+      assert.dom('[data-test-name][data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').hasClass('font-semibold');
+      assert.dom('[data-test-name][data-test-mox-list-header-item] [data-test-mox-list-header-sort-asc]').hasStyle({ color: 'rgb(107, 114, 128)' });
+
+      assert.dom('[data-test-description][data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').doesNotHaveClass('text-white');
+      assert.dom('[data-test-description][data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').doesNotHaveClass('font-semibold');
+      assert.dom('[data-test-id][data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').doesNotHaveClass('text-white');
+      assert.dom('[data-test-id][data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').doesNotHaveClass('font-semibold');
+      assert.dom('[data-test-price][data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').doesNotHaveClass('text-white');
+      assert.dom('[data-test-price][data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').doesNotHaveClass('font-semibold');
+    });
+
+    test('it sorts list entries by column (descending)', async function (assert) {
+      let listItems = await findAll('[data-test-mox-list-row]');
+
+      assert.dom(listItems[0]).includesText('Lunar Curtain');
+      assert.dom(listItems[1]).includesText('Fire Veil');
+      assert.dom(listItems[2]).includesText('Stardust');
+      assert.dom(listItems[3]).includesText('Hi-Potion');
+
+      await click('[data-test-price] [data-test-mox-list-header-sort-desc]');
+
+      let updatedListItems = await findAll('[data-test-mox-list-row]');
+
+      assert.dom(updatedListItems[0]).includesText('Stardust');
+      assert.dom(updatedListItems[1]).includesText('Fire Veil');
+      assert.dom(updatedListItems[2]).includesText('Lunar Curtain');
+      assert.dom(updatedListItems[3]).includesText('Hi-Potion');
+    });
+
+    test('it sorts list entries by column (ascending)', async function (assert) {
+      let listItems = await findAll('[data-test-mox-list-row]');
+
+      assert.dom(listItems[0]).includesText('Lunar Curtain');
+      assert.dom(listItems[1]).includesText('Fire Veil');
+      assert.dom(listItems[2]).includesText('Stardust');
+      assert.dom(listItems[3]).includesText('Hi-Potion');
+
+      await click('[data-test-description] [data-test-mox-list-header-sort-asc]');
+
+      let updatedListItems = await findAll('[data-test-mox-list-row]');
+
+      assert.dom(updatedListItems[0]).includesText('Lunar Curtain');
+      assert.dom(updatedListItems[1]).includesText('Hi-Potion');
+      assert.dom(updatedListItems[2]).includesText('Stardust');
+      assert.dom(updatedListItems[3]).includesText('Fire Veil');
+    });
   });
 });

--- a/tests/integration/components/mox/list/item-test.js
+++ b/tests/integration/components/mox/list/item-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | mox/list/item', function(hooks) {
@@ -14,7 +14,9 @@ module('Integration | Component | mox/list/item', function(hooks) {
 
       assert.dom('[data-test-mox-list-header-item]').includesText('Hola');
       assert.dom('[data-test-mox-list-item]').doesNotExist();
-      assert.dom('[data-test-mox-list-header-item]').hasClass('text-gray-300');
+      assert.dom('[data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').hasClass('text-gray-300');
+      assert.dom('[data-test-mox-list-header-sort-asc]').doesNotExist();
+      assert.dom('[data-test-mox-list-header-sort-desc]').doesNotExist();
     });
 
     test('it can be hidden', async function (assert) {
@@ -23,6 +25,71 @@ module('Integration | Component | mox/list/item', function(hooks) {
       );
 
       assert.dom('[data-test-mox-list-header-item]').doesNotExist();
+    });
+
+    test('it renders the active state', async function (assert) {
+      await render(
+        hbs`<Mox::List::Item @isHeader={{true}} @isActive={{true}}>Hola</Mox::List::Item>`
+      );
+
+      assert.dom('[data-test-mox-list-header-item]').includesText('Hola');
+      assert.dom('[data-test-mox-list-item]').doesNotExist();
+      assert.dom('[data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').hasClass('text-white');
+      assert.dom('[data-test-mox-list-header-item] [data-test-mox-list-header-item-label]').hasClass('font-semibold');
+    });
+
+    test('it renders sorting controls', async function (assert) {
+      this.dummyAction = () => {};
+
+      await render(
+        hbs`<Mox::List::Item @isHeader={{true}} @sort={{this.dummyAction}}>Hola</Mox::List::Item>`
+      );
+
+      assert.dom('[data-test-mox-list-header-sort-asc]').exists();
+      assert.dom('[data-test-mox-list-header-sort-desc]').exists();
+    });
+
+    test('it sends the "desc" attribute when sorting and focusses the control (descending sort direction)', async function (assert) {
+      assert.expect(2);
+
+      this.dummyAction = (prop) => {
+        assert.equal(prop, 'desc');
+      };
+
+      await render(
+        hbs`<Mox::List::Item @isHeader={{true}} @sort={{this.dummyAction}}>Hola</Mox::List::Item>`
+      );
+
+      await click('[data-test-mox-list-header-sort-desc]');
+
+      assert.dom('[data-test-mox-list-header-sort-desc]').hasStyle({ color: 'rgb(6, 182, 212)' });
+    });
+
+    test('it sends the "asc" attribute when sorting and focusses the control (ascending sort direction)', async function (assert) {
+      assert.expect(2);
+
+      this.dummyAction = (prop) => {
+        assert.equal(prop, 'asc');
+      };
+
+      await render(
+        hbs`<Mox::List::Item @isHeader={{true}} @sort={{this.dummyAction}}>Hola</Mox::List::Item>`
+      );
+
+      await click('[data-test-mox-list-header-sort-asc]');
+
+      assert.dom('[data-test-mox-list-header-sort-asc]').hasStyle({ color: 'rgb(6, 182, 212)' });
+    });
+
+    test('it renders the sort controls accordingly when the header item is active', async function (assert) {
+      this.dummyAction = () => {};
+
+      await render(
+        hbs`<Mox::List::Item @isHeader={{true}} @isActive={{true}} @sort={{this.dummyAction}}>Hola</Mox::List::Item>`
+      );
+
+      assert.dom('[data-test-mox-list-header-sort-desc]').hasClass('text-gray-500');
+      assert.dom('[data-test-mox-list-header-sort-asc]').hasClass('text-gray-500');
     });
   });
 


### PR DESCRIPTION
Part of https://github.com/meroxa/product/issues/515

This adds controls to the `Mox::List` component's header columns that would allow users to sort table entries alphanumerically.

Additionally, this PR includes new size variations of the `Mox::Icon` component.

### Demo

![sb-moxlistsorted](https://user-images.githubusercontent.com/8811742/191294245-91988069-951f-409a-88e1-086e45415bc3.gif)
