### PR TITLE
fix(ci): upgrade to Node 16 to unblock release GH action

### DIFF
--- a/.changeset/swift-bottles-trade.md
+++ b/.changeset/swift-bottles-trade.md
@@ -1,0 +1,5 @@
+---
+'mx-ui-components': major
+---
+
+fix(ci): upgrade to Node 16 to unblock release GH action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Install Dependencies
         run: yarn

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Meroxa UI component library.
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.24 or above
-* Ember CLI v3.24 or above
-* Node.js v12 or above
+* Ember.js v4.0 or above
+* Ember CLI v4.0 or above
+* Node.js v16 or above
 
 
 Installation


### PR DESCRIPTION
Part of https://github.com/meroxa/platform-ui-v1/issues/342
Follow-up to https://github.com/ConduitIO/mx-ui-components/pull/25

The new version of storybook that has been upgraded via https://github.com/ConduitIO/mx-ui-components/pull/25 requires Node 16. With this upgrade of the Node engine's version in our Github workflows, we're unblocking the CI action for the automatic release process [which is currently failing during the dependency installation step](https://github.com/ConduitIO/mx-ui-components/actions/runs/3851262348/jobs/6572887144).

```bash
Run yarn
yarn install v1.22.19
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
error @storybook/ember-cli-storybook@0.6.0: The engine "node" is incompatible with this module. Expected version ">= 16". Got "1[4](https://github.com/ConduitIO/mx-ui-components/actions/runs/3851262348/jobs/6572887144#step:4:5).21.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
[...]
```