### PR TITLE
feat: make accordion header toggle by default

### DIFF
--- a/.changeset/cool-pillows-argue.md
+++ b/.changeset/cool-pillows-argue.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": minor
+---
+
+feat: make accordion header toggle by default

--- a/addon/components/mox/accordion.hbs
+++ b/addon/components/mox/accordion.hbs
@@ -2,15 +2,29 @@
   <header class="flex items-center gap-x-4">
     <button
       class="text-cyan-500 hover:text-cyan-300 focus:text-cyan-300 transition-colors"
-      type="button" {{on "click" this.toggle}} aria-label="Open row" data-test-mox-accordion-button>
-      <Mox::Icon @iconName="chevron-right-24" class="transition {{if this.isOpen "rotate-90"}}" />
+      type="button"
+      {{on "click" this.toggle}}
+      aria-label="Open row"
+      data-test-mox-accordion-button
+    >
+      <Mox::Icon @iconName="chevron-right-24" class="transition {{if this.isOpen 'rotate-90'}}" />
     </button>
     {{#if @route}}
-      <Mox::Link @route={{@route}} @model={{@model}} class="flex items-center gap-x-4" data-test-mox-accordion-header-link>
+      <Mox::Link
+        @route={{@route}}
+        @model={{@model}}
+        class="flex items-center gap-x-4"
+        data-test-mox-accordion-header-link
+      >
         {{yield to="header"}}
       </Mox::Link>
     {{else}}
-      <div class="flex items-center gap-x-4 text-white" data-test-mox-accordion-header>
+      <div
+        class="flex items-center gap-x-4 text-white"
+        role="button"
+        data-test-mox-accordion-header
+        {{on "click" this.toggle}}
+      >
         {{yield to="header"}}
       </div>
     {{/if}}

--- a/tests/integration/components/mox/accordion-test.js
+++ b/tests/integration/components/mox/accordion-test.js
@@ -4,10 +4,10 @@ import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 
-module('Integration | Component | mox/accordion', function(hooks) {
+module('Integration | Component | mox/accordion', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders (default)', async function(assert) {
+  test('it renders (default)', async function (assert) {
     await render(hbs`
       <Mox::Accordion>
         <:header>
@@ -25,7 +25,7 @@ module('Integration | Component | mox/accordion', function(hooks) {
     assert.dom('[data-test-mox-accordion-body]').doesNotExist();
   });
 
-  test('it renders (with a link)', async function(assert) {
+  test('it renders (with a link)', async function (assert) {
     await render(hbs`
       <Mox::Accordion @route="application">
         <:header>
@@ -43,7 +43,7 @@ module('Integration | Component | mox/accordion', function(hooks) {
     assert.dom('[data-test-mox-accordion-body]').doesNotExist();
   });
 
-  test('it hides the body by default', async function(assert) {
+  test('it hides the body by default', async function (assert) {
     await render(hbs`
       <Mox::Accordion>
         <:header>
@@ -58,7 +58,7 @@ module('Integration | Component | mox/accordion', function(hooks) {
     assert.dom('[data-test-mox-accordion-body]').doesNotExist();
   });
 
-  test('it displays the body if @isOpen is set to true', async function(assert) {
+  test('it displays the body if @isOpen is set to true', async function (assert) {
     await render(hbs`
       <Mox::Accordion @isOpen={{true}}>
         <:header>
@@ -73,7 +73,7 @@ module('Integration | Component | mox/accordion', function(hooks) {
     assert.dom('[data-test-mox-accordion-body]').includesText('Que tal');
   });
 
-  test('it allows opening the accordion view via click', async function(assert) {
+  test('it allows opening the accordion view via click', async function (assert) {
     await render(hbs`
       <Mox::Accordion>
         <:header>
@@ -92,7 +92,7 @@ module('Integration | Component | mox/accordion', function(hooks) {
     assert.dom('[data-test-mox-accordion-body]').includesText('Que tal');
   });
 
-  test('it allows closing the accordion view via click', async function(assert) {
+  test('it allows closing the accordion view via click', async function (assert) {
     await render(hbs`
       <Mox::Accordion @isOpen={{true}}>
         <:header>
@@ -111,7 +111,7 @@ module('Integration | Component | mox/accordion', function(hooks) {
     assert.dom('[data-test-mox-accordion-body]').doesNotExist();
   });
 
-  test('it is accessible (closed state)', async function(assert) {
+  test('it is accessible (closed state)', async function (assert) {
     await render(hbs`
       <div class="bg-gray-900">
         <Mox::Accordion>
@@ -129,7 +129,7 @@ module('Integration | Component | mox/accordion', function(hooks) {
     assert.ok(true, 'it is accessible in its closed state');
   });
 
-  test('it is accessible (open state)', async function(assert) {
+  test('it is accessible (open state)', async function (assert) {
     await render(hbs`
       <div class="bg-gray-900">
         <Mox::Accordion @isOpen={{true}}>
@@ -145,5 +145,20 @@ module('Integration | Component | mox/accordion', function(hooks) {
 
     await a11yAudit();
     assert.ok(true, 'it is accessible in its open state');
+  });
+
+  test('it makes the header title toggleable by default if no route arg is passed', async function (assert) {
+    await render(hbs`
+    <Mox::Accordion>
+      <:header>
+        Hola
+      </:header>
+      <:body>
+        Que tal
+      </:body>
+    </Mox::Accordion>
+  `);
+    await click('[data-test-mox-accordion-header]');
+    assert.dom('[data-test-mox-accordion-body]').includesText('Que tal');
   });
 });


### PR DESCRIPTION
Adds small functionality to the accordion, that makes the header toggleable by default