### PR TITLE
ci(dependabot): allow automatic upgrade of deps (patch version)

### DIFF
--- a/.changeset/tiny-boxes-live.md
+++ b/.changeset/tiny-boxes-live.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": patch
+---
+
+ci(dependabot): allow automatic upgrade of deps (patch version)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Additional docs: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: ".github:"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(misc): "

--- a/.github/workflows/dependabot-automerge-js.yml
+++ b/.github/workflows/dependabot-automerge-js.yml
@@ -1,0 +1,39 @@
+# This action automatically merges dependabot PRs that update javascript dependencies (only patch updates).
+# Based on: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+
+name: Dependabot auto-merge
+on:
+  pull_request:
+    # Run this action when dependabot labels the PR, we care about the 'javascript' label.
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot-js:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'javascript') }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve PR
+        # Approve only patch and minor updates
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        # Enable auto-merging only for patch updates
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of change
<!-- link to JIRA ticket(s), github issue(s), and/or write an explanation-->

Part of https://github.com/meroxa/engineering/issues/51

With this change, dependency upgrades to the latest patch version of an npm package will be automatically approved and merged.

This is excluding the automation of `minor` version upgrades. This way, we still have enough time for additional, manual testing of updates of dependencies that may lead to UX-breaking changes.