### PR TITLE
feat(mox): add mox::card component

### DIFF
--- a/.changeset/mean-news-tease.md
+++ b/.changeset/mean-news-tease.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": minor
+---
+
+feat(mox): add mox::card component

--- a/addon/components/mox/card.hbs
+++ b/addon/components/mox/card.hbs
@@ -1,0 +1,37 @@
+<article
+  class="w-full bg-gray-800 rounded-lg border-solid border-2 border-gray-800 transition hover:border-cyan-500 focus-within:border-cyan-700 text-white"
+  data-test-mox-card
+  ...attributes
+>
+  <div class="flex items-center justify-between">
+
+    <Mox::Card::Main @route={{@route}} @model={{@model}} @onClick={{@onClick}}>
+
+      {{#if (has-block "icon")}}
+        <div class="bg-gray-900 rounded p-3" data-test-mox-card-icon>
+          {{yield to="icon"}}
+        </div>
+      {{/if}}
+
+      <div class="overflow-hidden">
+        <h3 class="text-xl font-semibold normal-case text-left truncate flex gap-x-2 text-white items-center" data-test-mox-card-title>
+          {{yield to="title"}}
+        </h3>
+        <p class="text-gray-300 text-xs truncate text-left" data-test-mox-card-subtitle>
+          {{yield to="subtitle"}}
+        </p>
+      </div>
+
+    </Mox::Card::Main>
+
+    {{#if (has-block "menu")}}
+      <div
+        class="flex items-center justify-center p-4 cursor-pointer h-full"
+        data-test-mox-card-menu
+      >
+        {{yield to="menu"}}
+      </div>
+    {{/if}}
+
+  </div>
+</article>

--- a/addon/components/mox/card/main.hbs
+++ b/addon/components/mox/card/main.hbs
@@ -1,0 +1,23 @@
+{{#if @route}}
+  <Mox::Link
+    @route={{@route}}
+    @model={{@model}}
+    class="flex w-11/12 items-center justify-start p-4 gap-x-4 cursor-pointer"
+    data-test-mox-card-link
+  >
+
+    {{yield}}
+
+  </Mox::Link>
+{{else}}
+  <button
+    type="button"
+    class="flex w-11/12 items-center justify-start p-4 gap-x-4 cursor-pointer"
+    {{on "click" this.onClick}}
+    data-test-mox-card-button
+  >
+
+    {{yield}}
+
+  </button>
+{{/if}}

--- a/addon/components/mox/card/main.js
+++ b/addon/components/mox/card/main.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { isPresent } from '@ember/utils';
+
+export default class MoxCardMainComponent extends Component {
+  @action
+  onClick() {
+    if (isPresent(this.args.onClick)) {
+      this.args.onClick();
+    }
+  }
+}

--- a/app/components/mox/card.js
+++ b/app/components/mox/card.js
@@ -1,0 +1,1 @@
+export { default } from 'mx-ui-components/components/mox/card';

--- a/app/components/mox/card/main.js
+++ b/app/components/mox/card/main.js
@@ -1,0 +1,1 @@
+export { default } from 'mx-ui-components/components/mox/card/main';

--- a/stories/header.css
+++ b/stories/header.css
@@ -1,6 +1,6 @@
 .wrapper {
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  border-bottom: 1px solid rgb(0 0 0 / 10%);
   padding: 15px 20px;
   display: flex;
   align-items: center;

--- a/stories/mox-card.stories.js
+++ b/stories/mox-card.stories.js
@@ -1,0 +1,138 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Mox/Mox::Card',
+  argTypes: {
+    title: { control: 'text' },
+    subtitle: { control: 'text' },
+    idd: { control: 'text' },
+    icon: { control: 'text' },
+    logo: { control: 'text' },
+    logoAlt: { control: 'text' },
+    buttonType: { control: 'text' },
+  },
+  parameters: {
+    backgrounds: {
+      default: 'Dark',
+      values: [
+        {
+          name: 'White',
+          value: '#ffffff',
+        },
+        {
+          name: 'Mute',
+          value: '#FBFBFB',
+        },
+        {
+          name: 'Dark',
+          value: '#111827',
+        },
+        {
+          name: 'Sky',
+          value: '#06B6D4',
+        },
+      ],
+    },
+  },
+};
+
+const Template = (args) => ({
+  template: hbs`
+  <div class="flex flex-col space-y-4 box-border w-container">
+    <Mox::Card>
+      <:title>
+        {{this.title}}
+      </:title>
+      <:subtitle>
+        {{this.subtitle}}
+      </:subtitle>
+    </Mox::Card>
+  </div>`,
+  context: args,
+  parameters: {
+    background: 'Dark',
+  },
+});
+
+const IconTemplate = (args) => ({
+  template: hbs`
+    <div class="flex flex-col space-y-4 box-border w-container">
+      <Mox::Card>
+        <:icon>
+          <Mox::Icon @iconName={{this.icon}} class="text-white" />
+        </:icon>
+        <:title>
+          <span>{{this.title}}</span>
+          <Mox::Badge @status="healthy">Running</Mox::Badge>
+        </:title>
+        <:subtitle>
+          {{this.subtitle}}
+        </:subtitle>
+        <:menu>
+          <button type="button">
+            <Mox::Icon @iconName="action-menu-16" class="text-white" />
+          </button>
+        </:menu>
+      </Mox::Card>
+    </div>
+  `,
+  context: args,
+});
+
+const LogoTemplate = (args) => ({
+  template: hbs`
+    <div class="flex flex-col space-y-4 box-border w-container">
+      <Mox::Card>
+        <:icon>
+          <img src={{this.logo}} alt={{this.logoAlt}} class="h-6 w-6" />
+        </:icon>
+        <:title>
+          {{this.title}}
+        </:title>
+        <:subtitle>
+          {{this.subtitle}}
+        </:subtitle>
+        <:menu>
+          <button type="button">
+            <Mox::Icon @iconName="action-menu-16" class="text-white" />
+          </button>
+        </:menu>
+      </Mox::Card>
+    </div>
+  `,
+  context: args,
+});
+
+export const WithIcon = IconTemplate.bind({});
+WithIcon.args = {
+  title: 'ecom-search-update',
+  subtitle: 'JavaScript · Turbine Application · Deployed to Common · Feb 23',
+  idd: 'ecom',
+  icon: 'connectors-16',
+  logo: null,
+  buttonType: null,
+  small: false,
+};
+
+export const WithLogo = LogoTemplate.bind({});
+WithLogo.args = {
+  title: 'ecom-search-update-but-with-a-veryveryveryveryveryvery-elaborate-text',
+  subtitle: 'JavaScript · Turbine Application · Deployed to Common · Feb 23',
+  idd: 'ecom',
+  icon: null,
+  logo: '/brand-logo-example.svg',
+  logoAlt: 'Meroxa',
+  buttonType: null,
+  small: false,
+};
+
+export const NoLogoNoMenu = Template.bind({});
+NoLogoNoMenu.args = {
+  title: 'ecom-search-update',
+  subtitle: 'JavaScript · Turbine Application · Deployed to Common · Feb 23',
+  idd: 'ecom',
+  icon: null,
+  logo: null,
+  buttonType: null,
+  small: false,
+};

--- a/tests/dummy/public/svg-defs.svg
+++ b/tests/dummy/public/svg-defs.svg
@@ -25,12 +25,6 @@
       <path d="M6 7C5.7 7 5.5 6.9 5.3 6.7L0.3 1.7C-0.1 1.3 -0.1 0.7 0.3 0.3C0.7 -0.1 1.3 -0.1 1.7 0.3L6 4.6L10.3 0.3C10.7 -0.1 11.3 -0.1 11.7 0.3C12.1 0.7 12.1 1.3 11.7 1.7L6.7 6.7C6.5 6.9 6.3 7 6 7Z"/>
     </symbol>
 
-    <symbol id="action-menu-16" viewBox="0 0 16 16">
-      <circle cx="8" cy="3" r="1.5"/>
-      <circle cx="8" cy="8" r="1.5"/>
-      <circle cx="8" cy="13" r="1.5"/>
-    </symbol>
-
     <symbol id="right-arrow-16" viewBox="0 0 16 16">
       <path d="M7 6.5C7 6.8 6.9 7 6.7 7.2L1.7 12.2C1.3 12.6 0.7 12.6 0.3 12.2C-0.0999999 11.8 -0.0999999 11.2 0.3 10.8L4.6 6.5L0.3 2.2C-0.0999999 1.8 -0.0999999 1.2 0.3 0.8C0.7 0.400001 1.3 0.400001 1.7 0.8L6.7 5.8C6.9 6 7 6.2 7 6.5Z"/>
     </symbol>
@@ -137,6 +131,12 @@
 
     <symbol id="info-circle-24" width="24" height="24" viewBox="0 0 24 24" fill="none">
       <path d="M13 16H12V12H11M12 8H12.01M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+
+    <symbol id="action-menu-16" viewBox="0 0 16 16">
+      <circle cx="8" cy="3" r="1.1"/>
+      <circle cx="8" cy="8" r="1.1"/>
+      <circle cx="8" cy="13" r="1.1"/>
     </symbol>
   </defs>
 </svg>

--- a/tests/integration/components/mox/card-test.js
+++ b/tests/integration/components/mox/card-test.js
@@ -1,0 +1,139 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Integration | Component | mox/card', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the title', async function (assert) {
+    await render(hbs`
+      <Mox::Card>
+        <:title>
+          Grandia
+        </:title>
+        <:subtitle>
+          PS1 · RPG · 1997
+        </:subtitle>
+      </Mox::Card>
+    `);
+
+    assert.dom('[data-test-mox-card]').includesText('Grandia');
+    assert.dom('[data-test-mox-card]').includesText('PS1 · RPG · 1997');
+    assert.dom('[data-test-mox-card-title]').includesText('Grandia');
+    assert
+      .dom('[data-test-mox-card-subtitle]')
+      .includesText('PS1 · RPG · 1997');
+  });
+
+  test('it renders the link element if a route is passed', async function (assert) {
+    await render(hbs`
+      <Mox::Card @route="application">
+        <:title>
+          Shadowhearts II
+        </:title>
+        <:subtitle>
+          PS2 · RPG · 2002
+        </:subtitle>
+      </Mox::Card>
+    `);
+
+    assert.dom('[data-test-mox-card] a').exists();
+    assert.dom('[data-test-mox-card-link]').exists();
+    assert.dom('[data-test-mox-card-button]').doesNotExist();
+    assert.dom('[data-test-mox-card-link]').includesText('Shadowhearts');
+    assert.dom('[data-test-mox-card-link]').includesText('PS2 · RPG · 2002');
+  });
+
+  test('it renders an icon placeholder', async function (assert) {
+    await render(hbs`
+      <Mox::Card @route="application">
+        <:icon>
+          an icon
+        </:icon>
+        <:title>
+          FFVII
+        </:title>
+        <:subtitle>
+          PS1 · RPG · 1994
+        </:subtitle>
+      </Mox::Card>
+    `);
+
+    assert.dom('[data-test-mox-card]').includesText('an icon');
+    assert.dom('[data-test-mox-card-icon]').includesText('an icon');
+  });
+
+  test('it renders a menu placeholder', async function (assert) {
+    await render(hbs`
+      <Mox::Card @route="application">
+        <:title>
+          FFVII
+        </:title>
+        <:subtitle>
+          PS1 · RPG · 1994
+        </:subtitle>
+        <:menu>
+          a menuuuu
+        </:menu>
+      </Mox::Card>
+    `);
+
+    assert.dom('[data-test-mox-card]').includesText('a menuuu');
+    assert.dom('[data-test-mox-card-menu]').includesText('a menuuu');
+  });
+
+  test('it triggers the @onClick action when the button is clicked', async function (assert) {
+    assert.expect(1);
+
+    this.set('dummyAction', () => {
+      assert.ok(true, 'it triggers the onClick action');
+    });
+
+    await render(hbs`
+      <Mox::Card @onClick={{this.dummyAction}}>
+        <:title>
+          FFVII
+        </:title>
+        <:subtitle>
+          PS1 · RPG · 1994
+        </:subtitle>
+      </Mox::Card>
+    `);
+
+    await click('[data-test-mox-card-button]');
+  });
+
+  test('it has no accessibility issues (button mode)', async function (assert) {
+    await render(hbs`
+      <Mox::Card @onClick={{this.dummyAction}}>
+        <:title>
+          FFVII
+        </:title>
+        <:subtitle>
+          PS1 · RPG · 1994
+        </:subtitle>
+      </Mox::Card>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y detected');
+  });
+
+  test('it has no accessibility issues (link mode)', async function (assert) {
+    await render(hbs`
+      <Mox::Card @route="application">
+        <:title>
+          FFVII
+        </:title>
+        <:subtitle>
+          PS1 · RPG · 1994
+        </:subtitle>
+      </Mox::Card>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y detected');
+  });
+});

--- a/tests/integration/components/mox/card/main-test.js
+++ b/tests/integration/components/mox/card/main-test.js
@@ -1,0 +1,81 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Integration | Component | mox/card/main', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the block', async function (assert) {
+    await render(hbs`
+      <Mox::Card::Main>
+        template block text
+      </Mox::Card::Main>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+
+  test('it renders the link element if a route is passed', async function (assert) {
+    await render(hbs`
+      <Mox::Card::Main @route="application">
+        template block text
+      </Mox::Card::Main>
+    `);
+
+    assert.dom('[data-test-mox-card-link]').exists();
+    assert.dom('[data-test-mox-card-button]').doesNotExist();
+    assert.dom('[data-test-mox-card-link]').hasText('template block text');
+  });
+
+  test('it renders the button element if no route is passed', async function (assert) {
+    await render(hbs`
+      <Mox::Card::Main>
+        template block text
+      </Mox::Card::Main>
+    `);
+
+    assert.dom('[data-test-mox-card-button]').exists();
+    assert.dom('[data-test-mox-card-link]').doesNotExist();
+    assert.dom('[data-test-mox-card-button]').hasText('template block text');
+  });
+
+  test('it triggers the @onClick action when clicked', async function (assert) {
+    assert.expect(1);
+
+    this.set('dummyAction', () => {
+      assert.ok(true, 'it triggers the onClick action');
+    });
+
+    await render(hbs`
+      <Mox::Card::Main @onClick={{this.dummyAction}}>
+        template block text
+      </Mox::Card::Main>
+    `);
+
+    await click('[data-test-mox-card-button]');
+  });
+
+  test('it has no accessibility issues (button mode)', async function (assert) {
+    await render(hbs`
+      <Mox::Card::Main>
+        template block text
+      </Mox::Card::Main>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y detected');
+  });
+
+  test('it has no accessibility issues (link mode)', async function (assert) {
+    await render(hbs`
+      <Mox::Card::Main @route="application">
+        template block text
+      </Mox::Card::Main>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y detected');
+  });
+});


### PR DESCRIPTION
Closes https://github.com/meroxa/platform-ui-v1/issues/920

WIth this change, we're adding a new `Mox::Card` component to the UI library which can be used in e.g. list views.

### Screens

![carditem](https://github.com/ConduitIO/mx-ui-components/assets/8811742/17da1db4-52e1-45f0-8b35-2d8599caef1d)
