### PR TITLE
config(depr.): update depr. workflow for 4.x warnings

### DIFF
--- a/.changeset/blue-waves-travel.md
+++ b/.changeset/blue-waves-travel.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": patch
+---
+
+config(depr.): update depr. workflow for 4.x warnings

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build-storybook": "yarn run build:prod --"
   },
   "dependencies": {
+    "@ember/string": "^3.1.1",
     "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",
@@ -54,7 +55,6 @@
     "@changesets/cli": "^2.24.4",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.3",
-    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.9.3",
     "@embroider/test-setup": "^2.1.1",
     "@glimmer/component": "^1.1.2",

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -1,42 +1,45 @@
 /* eslint-disable no-undef */
 self.deprecationWorkflow = self.deprecationWorkflow || {};
 self.deprecationWorkflow.config = {
-  /* eslint-enable no-undef */
   workflow: [
-    { handler: 'throw', matchId: 'ember-global' },
-    { handler: 'throw', matchId: 'ember.component.reopen' },
-    { handler: 'throw', matchId: 'ember.built-in-components.import' },
-    { handler: 'throw', matchId: 'ember.built-in-components.reopen' },
-    {
-      handler: 'throw',
-      matchId: 'deprecated-run-loop-and-computed-dot-access',
-    },
+    /* Ember deprecations 4.x */
+    { handler: 'throw', matchId: 'remove-owner-inject' },
+    { handler: 'throw', matchId: 'ember-polyfills.deprecate-assign' },
     { handler: 'throw', matchId: 'implicit-injections' },
-    { handler: 'throw', matchId: 'route-render-template' },
-    { handler: 'throw', matchId: 'manager-capabilities.modifiers-3-13' },
+    { handler: 'throw', matchId: 'deprecate-auto-location' },
+    { handler: 'throw', matchId: 'setting-on-hash' },
+    { handler: 'throw', matchId: 'deprecate-ember-error' },
+    { handler: 'throw', matchId: 'ember-string.from-ember-module' },
+    /* Ember CLI deprecations 4.x */
     {
       handler: 'throw',
-      matchId: 'ember.built-in-components.legacy-arguments',
+      matchId: 'ember-cli.blueprint.add-bower-package-to-project',
     },
-    { handler: 'throw', matchId: 'ember-modifier.use-modify' },
-    { handler: 'throw', matchId: 'ember-modifier.no-args-property' },
-    { handler: 'throw', matchId: 'ember-modifier.no-element-property' },
-    { handler: 'throw', matchId: 'autotracking.mutation-after-consumption' },
-    { handler: 'throw', matchId: 'ember-modifier.function-based-options' },
     {
       handler: 'throw',
-      matchId: 'ember-keyboard.keyboard-first-responder-on-focus-mixin',
+      matchId: ' ember-cli.blueprint.add-bower-packages-to-project',
+    },
+    { handler: 'throw', matchId: 'ember-cli.building-bower-packages' },
+    { handler: 'throw', matchId: 'ember-cli.project.bower-dependencies' },
+    { handler: 'throw', matchId: 'ember-cli.project.bower-directory' },
+    {
+      handler: 'throw',
+      matchId: 'ember-cli.blacklist-whitelist-build-options',
+    },
+    { handler: 'throw', matchId: 'ember-cli.ember-cli-jshint-support' },
+    { handler: 'throw', matchId: 'ember-cli.vendor-shim-blueprint' },
+    /* Ember Data deprecations 4.x */
+    { handler: 'silence', matchId: 'ember-data:deprecate-array-like' },
+    { handler: 'silence', matchId: 'ember-data:deprecate-early-static' },
+    {
+      handler: 'silence',
+      matchId: 'ember-data:deprecate-non-strict-relationships',
     },
     {
       handler: 'silence',
-      matchId: 'ember-data:method-calls-on-destroyed-store',
+      matchId: 'ember-data:deprecate-promise-many-array-behaviors',
     },
-    { handler: 'throw', matchId: 'ember-keyboard.first-responder-inputs' },
-    { handler: 'throw', matchId: 'ember-keyboard.ember-keyboard-mixin' },
-    { handler: 'throw', matchId: 'manager-capabilities.modifiers-3-13' },
-    { handler: 'throw', matchId: 'autotracking.mutation-after-consumption' },
-    { handler: 'throw', matchId: 'this-property-fallback' },
-    { handler: 'throw', matchId: 'routing.transition-methods' },
-    { handler: 'throw', matchId: 'ember-data:method-calls-on-destroyed-store' },
+    { handler: 'silence', matchId: 'ember-data:deprecate-store-find' },
+    { handler: 'silence', matchId: 'ember-data:deprecate-promise-proxies' },
   ],
 };

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -29,17 +29,17 @@ self.deprecationWorkflow.config = {
     { handler: 'throw', matchId: 'ember-cli.ember-cli-jshint-support' },
     { handler: 'throw', matchId: 'ember-cli.vendor-shim-blueprint' },
     /* Ember Data deprecations 4.x */
-    { handler: 'silence', matchId: 'ember-data:deprecate-array-like' },
-    { handler: 'silence', matchId: 'ember-data:deprecate-early-static' },
+    { handler: 'throw', matchId: 'ember-data:deprecate-array-like' },
+    { handler: 'throw', matchId: 'ember-data:deprecate-early-static' },
     {
-      handler: 'silence',
+      handler: 'throw',
       matchId: 'ember-data:deprecate-non-strict-relationships',
     },
     {
-      handler: 'silence',
+      handler: 'throw',
       matchId: 'ember-data:deprecate-promise-many-array-behaviors',
     },
-    { handler: 'silence', matchId: 'ember-data:deprecate-store-find' },
-    { handler: 'silence', matchId: 'ember-data:deprecate-promise-proxies' },
+    { handler: 'throw', matchId: 'ember-data:deprecate-store-find' },
+    { handler: 'throw', matchId: 'ember-data:deprecate-promise-proxies' },
   ],
 };

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -10,6 +10,7 @@ self.deprecationWorkflow.config = {
     { handler: 'throw', matchId: 'setting-on-hash' },
     { handler: 'throw', matchId: 'deprecate-ember-error' },
     { handler: 'throw', matchId: 'ember-string.from-ember-module' },
+    { handler: 'silence', matchId: 'ember-string.add-package' },
     /* Ember CLI deprecations 4.x */
     {
       handler: 'throw',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,10 +2073,10 @@
     ember-cli-babel "^7.26.6"
     ember-modifier-manager-polyfill "^1.2.0"
 
-"@ember/string@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.0.1.tgz#42cf032031a4432c2dd69c327ae1876d2c13df9c"
-  integrity sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==
+"@ember/string@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.1.1.tgz#0a5ac0d1e4925259e41d5c8d55ef616117d47ff0"
+  integrity sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==
   dependencies:
     ember-cli-babel "^7.26.6"
 


### PR DESCRIPTION
Part of https://github.com/meroxa/platform-ui-v1/issues/727

With this change, we're updating the addon's [deprecation workflow configuration](https://github.com/mixonic/ember-cli-deprecation-workflow) to account for [4.x warnings from ember, ember-data and ember-cli](https://deprecations.emberjs.com/) respectively.


## Todos

- [x] resolve all deprecation warnings (none)
- [x] add changelog (patch version)