### PR TITLE
Theme Switcher Component 

### DIFF
--- a/.changeset/mean-bikes-laugh.md
+++ b/.changeset/mean-bikes-laugh.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": minor
+---
+
+Add Theme Switcher Component 

--- a/addon/components/mox/theme-switch.hbs
+++ b/addon/components/mox/theme-switch.hbs
@@ -1,0 +1,25 @@
+<div class="mox-theme-switch" ...attributes>
+  <div class="flex items-center space-x-2 relative {{if this.isChecked "text-gray-800"}}">
+    <input
+      id={{this.fieldId}}
+      aria-label={{this.label}}
+      type="checkbox"
+      class="transform appearance-none outline-none
+      flex items-center rounded-full p-1 cursor-pointer transition"
+      checked={{this.isChecked}}
+      {{on 'change' (fn this.switchTheme this.otherTheme)}}
+      data-test-mox-theme-switch
+    />
+    <div class="mox-theme-switch-icon pointer-events-none {{if this.isChecked "is-checked"}}">
+      {{#if (eq this.currentTheme "dark")}}
+        <div class="text-white" data-test-mox-theme-switch-current="dark">
+          {{yield to="dark-icon"}}
+        </div>
+      {{else}}
+        <div class="text-gray-900" data-test-mox-theme-switch-current="light">
+          {{yield to="light-icon"}}
+        </div>
+      {{/if}}
+    </div>
+  </div>
+</div>

--- a/addon/components/mox/theme-switch.js
+++ b/addon/components/mox/theme-switch.js
@@ -1,0 +1,42 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { dasherize } from '@ember/string';
+import { tracked } from '@glimmer/tracking';
+
+export default class MoxThemeSwitchComponent extends Component {
+  @tracked
+  isChecked = false;
+
+  allThemes = ['dark', 'light'];
+
+  constructor() {
+    super(...arguments);
+    this.isChecked = this.args.isChecked || false;
+  }
+
+  get currentTheme() {
+    return this.isChecked ? 'dark' : 'light';
+  }
+
+  get otherTheme() {
+    return this.allThemes.filter(theme => theme !== this.currentTheme)[0];
+  }
+
+  get label() {
+    if (this.args.label) {
+      return this.args.label;
+    }
+
+    return `Use ${this.otherTheme} mode`;
+  }
+
+  get fieldId() {
+    return this.args.id ? this.args.id : dasherize(this.label);
+  }
+
+  @action
+  switchTheme(newTheme, event) {
+    this.isChecked = !this.isChecked;
+    this.args.toggleAction(newTheme, event);
+  }
+}

--- a/addon/styles/mx-ui-components.css
+++ b/addon/styles/mx-ui-components.css
@@ -1,10 +1,12 @@
 .mxa-toggle input:checked,
-.mox-toggle input:checked {
+.mox-toggle input:checked,
+.mox-theme-switch input:checked {
   background-image: none;
 }
 
 .mxa-toggle input:after,
-.mox-toggle input:after {
+.mox-toggle input:after,
+.mox-theme-switch input:after {
   content: "";
   height: 20px;
   width: 20px;
@@ -36,6 +38,55 @@
   width: 15px;
   top: 2px;
   left: 2px;
+}
+
+.mox-theme-switch input {
+  height: 1.5rem;
+  width: 2.5rem;
+  outline: 2px solid #e5e7eb; /* bg-gray-200 */
+  background-color: #e5e7eb; /* bg-gray-200 */
+  outline-offset: 0;
+  border: none;
+}
+
+.mox-theme-switch input:checked {
+  background-color: #1f2937; /* bg-gray-800 */
+  outline: 2px solid #1f2937; /* bg-gray-800 */
+  color: #1f2937; /* bg-gray-800 */
+}
+
+.mox-theme-switch input:focus {
+  outline: 2px solid #06B6D4;
+  box-shadow: none;
+  outline-offset: 0;
+}
+
+.mox-theme-switch input:after {
+  height: 18px;
+  width: 18px;
+  top: 3px;
+  left: 3px;
+}
+
+.mox-theme-switch-icon {
+  position: absolute;
+  left: -4px;
+  top: 4px;
+  right: auto;
+  display: block;
+  outline: none;
+  transform: translateX(0);
+  transition: transform 0.15s;
+  transition-timing-function: ease-in-out;
+}
+
+.mox-theme-switch input:checked:after,
+.mox-theme-switch-icon.is-checked {
+  transform: translateX(15px);
+}
+
+.mox-theme-switch input:checked:after {
+  background-color: transparent;
 }
 
 .mxa-toggle input:checked:after,

--- a/app/components/mox/theme-switch.js
+++ b/app/components/mox/theme-switch.js
@@ -1,0 +1,1 @@
+export { default } from 'mx-ui-components/components/mox/theme-switch';

--- a/stories/mox-accordion.stories.js
+++ b/stories/mox-accordion.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Accordion',
+  title: 'Mox Dark/Mox::Accordion',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-badge.stories.js
+++ b/stories/mox-badge.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Badge',
+  title: 'Mox Dark/Mox::Badge',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-button.stories.js
+++ b/stories/mox-button.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Button',
+  title: 'Mox Dark/Mox::Button',
   argTypes: {
     children: { control: 'text' },
     buttonType: { control: 'text' },

--- a/stories/mox-card.stories.js
+++ b/stories/mox-card.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Card',
+  title: 'Mox Dark/Mox::Card',
   argTypes: {
     title: { control: 'text' },
     subtitle: { control: 'text' },

--- a/stories/mox-code-block.stories.js
+++ b/stories/mox-code-block.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::CodeBlock',
+  title: 'Mox Dark/Mox::CodeBlock',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-confirm-modal.stories.js
+++ b/stories/mox-confirm-modal.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Mox/Mox::ConfirmModal',
+  title: 'Mox Dark/Mox::ConfirmModal',
 };
 
 const actionsData = {

--- a/stories/mox-form-field.stories.js
+++ b/stories/mox-form-field.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::FormField',
+  title: 'Mox Dark/Mox::FormField',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-global-header.stories.js
+++ b/stories/mox-global-header.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::GlobalHeader',
+  title: 'Mox Dark/Mox::GlobalHeader',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-icon.stories.js
+++ b/stories/mox-icon.stories.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 let colorOptions = ['text-white', 'text-gray-300', 'text-red-500', 'text-cyan-500'];
 
 export default {
-  title: 'Mox/Mox::Icon',
+  title: 'Mox Dark/Mox::Icon',
   argTypes: {
     color: {
       control: {

--- a/stories/mox-input.stories.js
+++ b/stories/mox-input.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Input',
+  title: 'Mox Dark/Mox::Input',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-label.stories.js
+++ b/stories/mox-label.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Label',
+  title: 'Mox Dark/Mox::Label',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-link.stories.js
+++ b/stories/mox-link.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Link',
+  title: 'Mox Dark/Mox::Link',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-list.stories.js
+++ b/stories/mox-list.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::List',
+  title: 'Mox Dark/Mox::List',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-modal-dialog.stories.js
+++ b/stories/mox-modal-dialog.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Mox/Mox::ModalDialog',
+  title: 'Mox Dark/Mox::ModalDialog',
 };
 
 const actionsData = {

--- a/stories/mox-modal.stories.js
+++ b/stories/mox-modal.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Mox/Mox::Modal',
+  title: 'Mox Dark/Mox::Modal',
 };
 
 const actionsData = {

--- a/stories/mox-navigation.stories.js
+++ b/stories/mox-navigation.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Navigation',
+  title: 'Mox Dark/Mox::Navigation',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-search-input.stories.js
+++ b/stories/mox-search-input.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::SearchInput',
+  title: 'Mox Dark/Mox::SearchInput',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-select.stories.js
+++ b/stories/mox-select.stories.js
@@ -24,7 +24,7 @@ const resourceTypes = [
 ];
 
 export default {
-  title: 'Mox/Mox::Select',
+  title: 'Mox Dark/Mox::Select',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-tabs.stories.js
+++ b/stories/mox-tabs.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Tabs',
+  title: 'Mox Dark/Mox::Tabs',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-text-area.stories.js
+++ b/stories/mox-text-area.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::TextArea',
+  title: 'Mox Dark/Mox::TextArea',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-theme-switch.stories.js
+++ b/stories/mox-theme-switch.stories.js
@@ -1,0 +1,35 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Mox Dark/Mox::ThemeSwitch',
+  parameters: {
+    backgrounds: {
+      default: 'Dark',
+    },
+  },
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <Mox::ThemeSwitch @isChecked={{this.isChecked}}>
+      <:light-icon>
+        <Mox::Icon @iconName="sun" @size="small" />
+      </:light-icon>
+      <:dark-icon>
+        <Mox::Icon @iconName="moon" @size="small" />
+      </:dark-icon>
+    </Mox::ThemeSwitch>`,
+  context: args,
+});
+
+export const DefaultTheme = Template.bind({});
+DefaultTheme.args = {
+  message: '',
+  isChecked: false,
+};
+
+export const Checked = Template.bind({});
+Checked.args = {
+  message: '',
+  isChecked: true,
+};

--- a/stories/mox-toast.stories.js
+++ b/stories/mox-toast.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Toast',
+  title: 'Mox Dark/Mox::Toast',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-toggle.stories.js
+++ b/stories/mox-toggle.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox/Mox::Toggle',
+  title: 'Mox Dark/Mox::Toggle',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/stories/mox-typeahead-select.stories.js
+++ b/stories/mox-typeahead-select.stories.js
@@ -8,7 +8,7 @@ const options = [
 ];
 
 export default {
-  title: 'Mox/Mox::TypeaheadSelect',
+  title: 'Mox Dark/Mox::TypeaheadSelect',
   argTypes: {
     options: { control: 'text' },
     buttonType: { control: 'text' },

--- a/stories/mox-upload.stories.js
+++ b/stories/mox-upload.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@ember/object';
 
 export default {
-  title: 'Mox/Mox::Upload',
+  title: 'Mox Dark/Mox::Upload',
   parameters: {
     backgrounds: {
       default: 'Dark',

--- a/tests/dummy/public/svg-defs.svg
+++ b/tests/dummy/public/svg-defs.svg
@@ -138,5 +138,14 @@
       <circle cx="8" cy="8" r="1.1"/>
       <circle cx="8" cy="13" r="1.1"/>
     </symbol>
+
+    <symbol id="moon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" />
+    </symbol>
+
+    <symbol id="sun" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+    </symbol>
+
   </defs>
 </svg>

--- a/tests/integration/components/mox/theme-switch-test.js
+++ b/tests/integration/components/mox/theme-switch-test.js
@@ -1,0 +1,79 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+import sinon from 'sinon';
+
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Integration | Component | mox/theme-switch', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function() {
+    this.set('toggleAction', sinon.spy());
+    this.set('label', 'Paradis');
+  });
+
+  test('it displays a label for screenreader users (set via argument)', async function(assert) {
+    await render(hbs`<Mox::ThemeSwitch @toggleAction={{this.toggleAction}} @label={{this.label}} />`);
+    assert.dom('[data-test-mox-theme-switch]').hasAttribute('aria-label', 'Paradis');
+  });
+
+  test('it displays a label for screenreader users (fallback)', async function(assert) {
+    await render(hbs`<Mox::ThemeSwitch @toggleAction={{this.toggleAction}} />`);
+    assert.dom('[data-test-mox-theme-switch]').hasAttribute('aria-label', 'Use dark mode');
+  });
+
+  test('it is accessible with an external label', async function(assert) {
+    await render(hbs`
+      <label for="my-field-id">Toggle 1</label>
+      <Mox::ThemeSwitch @toggleAction={{this.toggleAction}} @id="my-field-id" />
+    `);
+    await a11yAudit();
+    assert.ok(true, 'no a11y detected');
+  });
+
+  test('it is accessible with the default label', async function(assert) {
+    await render(hbs`<Mox::ThemeSwitch @toggleAction={{this.toggleAction}} />`);
+    await a11yAudit();
+    assert.ok(true, 'no a11y detected');
+  });
+
+  test('it allows unchecking the component externally', async function(assert) {
+    await render(hbs`<Mox::ThemeSwitch @toggleAction={{this.toggleAction}} @isChecked={{false}} />`);
+
+    assert.dom('[data-test-mox-theme-switch-current="dark"]').doesNotExist();
+    assert.dom('[data-test-mox-theme-switch-current="light"]').exists();
+    assert.dom('[data-test-mox-theme-switch]').hasAttribute('aria-label', 'Use dark mode');
+  });
+
+  test('it allows checking the component externally', async function(assert) {
+    await render(hbs`<Mox::ThemeSwitch @toggleAction={{this.toggleAction}} @isChecked={{true}} />`);
+
+    assert.dom('[data-test-mox-theme-switch-current="light"]').doesNotExist();
+    assert.dom('[data-test-mox-theme-switch-current="dark"]').exists();
+    assert.dom('[data-test-mox-theme-switch]').hasAttribute('aria-label', 'Use light mode');
+  });
+
+  test('it triggers the external action when switching the toggle', async function(assert) {
+    await render(hbs`<Mox::ThemeSwitch @toggleAction={{this.toggleAction}} />`);
+    await click('[data-test-mox-theme-switch]');
+
+    assert.true(this.toggleAction.calledOnce);
+  });
+
+  test('it updates the UI when switching the toggle', async function(assert) {
+    await render(hbs`<Mox::ThemeSwitch @toggleAction={{this.toggleAction}} />`);
+
+    assert.dom('[data-test-mox-theme-switch-current="dark"]').doesNotExist();
+    assert.dom('[data-test-mox-theme-switch-current="light"]').exists();
+    assert.dom('[data-test-mox-theme-switch]').hasAttribute('aria-label', 'Use dark mode');
+
+    await click('[data-test-mox-theme-switch]');
+
+    assert.dom('[data-test-mox-theme-switch-current="light"]').doesNotExist();
+    assert.dom('[data-test-mox-theme-switch-current="dark"]').exists();
+    assert.dom('[data-test-mox-theme-switch]').hasAttribute('aria-label', 'Use light mode');
+  });
+});


### PR DESCRIPTION
Closes https://github.com/ConduitIO/mx-ui-components/issues/96

With this change, we're adding a `Mox::ThemeSwitch` UI component that can be reused across our auth pages and the dashboard.

### Screens

![darktolight2](https://github.com/ConduitIO/mx-ui-components/assets/8811742/ca121814-4016-40f7-b628-7f9a7fa1f2c7)


