### PR TITLE
Update mox::card UI + add new mox::article component

### DIFF
--- a/.changeset/wet-moose-lick.md
+++ b/.changeset/wet-moose-lick.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": minor
+---
+
+Update mox::card UI + add new mox::article component

--- a/addon/components/mox/article.hbs
+++ b/addon/components/mox/article.hbs
@@ -1,0 +1,7 @@
+<article
+  class="w-full p-8 bg-white dark:bg-gray-800 rounded-lg border-solid border-2 border-white dark:border-gray-800 transition text-gray-700 dark:text-white shadow-lg shadow-gray-800/20"
+  data-test-mox-article
+  ...attributes
+>
+  {{yield}}
+</article>

--- a/addon/components/mox/article/header.hbs
+++ b/addon/components/mox/article/header.hbs
@@ -1,0 +1,18 @@
+{{#if (or (has-block "title") (has-block "subtitle"))}}
+  <div class="flex flex-col space-y-2 w-full">
+    {{#if (has-block "title")}}
+      <h2 class="text-2xl font-semibold text-gray-800 dark:text-white w-full" data-test-mox-article-header-title>
+        {{yield to="title"}}
+      </h2>
+    {{/if}}
+    {{#if (has-block "subtitle")}}
+      <p class="text-gray-700 dark:text-gray-300 text-base w-full" data-test-mox-article-header-subtitle>
+        {{yield to="subtitle"}}
+      </p>
+    {{/if}}
+  </div>
+{{else}}
+  <h2 class="text-2xl font-semibold text-gray-800 dark:text-white mb-2 w-full" data-test-mox-article-header-title>
+    {{yield}}
+  </h2>
+{{/if}}

--- a/addon/components/mox/card.hbs
+++ b/addon/components/mox/card.hbs
@@ -1,5 +1,5 @@
 <article
-  class="w-full bg-gray-800 rounded-lg border-solid border-2 border-gray-800 transition hover:border-cyan-500 focus-within:border-cyan-700 text-white"
+  class="w-full bg-white dark:bg-gray-800 rounded-lg border-solid border-2 border-white dark:border-gray-800 transition hover:border-cyan-500 focus-within:border-cyan-700 text-gray-700 dark:text-white shadow-lg shadow-gray-800/20"
   data-test-mox-card
   ...attributes
 >
@@ -8,30 +8,44 @@
     <Mox::Card::Main @route={{@route}} @model={{@model}} @onClick={{@onClick}}>
 
       {{#if (has-block "icon")}}
-        <div class="bg-gray-900 rounded p-3" data-test-mox-card-icon>
+        <div class="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-white rounded p-3" data-test-mox-card-icon>
           {{yield to="icon"}}
         </div>
       {{/if}}
 
       <div class="overflow-hidden">
-        <h3 class="text-xl font-semibold normal-case text-left truncate flex gap-x-2 text-white items-center" data-test-mox-card-title>
+        <h3 class="text-xl font-semibold normal-case text-left overflow-hidden truncate flex gap-x-2 text-gray-800 dark:text-white items-center" data-test-mox-card-title>
           {{yield to="title"}}
         </h3>
-        <p class="text-gray-300 text-xs truncate text-left" data-test-mox-card-subtitle>
+        <p class="text-gray-500 dark:text-gray-300 text-xs truncate text-left" data-test-mox-card-subtitle>
           {{yield to="subtitle"}}
         </p>
       </div>
 
     </Mox::Card::Main>
 
-    {{#if (has-block "menu")}}
-      <div
-        class="flex items-center justify-center p-4 cursor-pointer h-full"
-        data-test-mox-card-menu
-      >
-        {{yield to="menu"}}
-      </div>
-    {{/if}}
+    <div class="flex items-center justify-end">
+      {{#if (has-block "details")}}
+        <Mox::Card::Aside @route={{@route}} @model={{@model}} @onClick={{@onClick}}>
+          <div
+            class="flex items-center justify-end h-full text-xs text-gray-600 dark:text-gray-200"
+            data-test-mox-card-details
+          >
+            {{yield to="details"}}
+          </div>
+        </Mox::Card::Aside>
+      {{/if}}
+
+
+      {{#if (has-block "menu")}}
+        <div
+          class="flex items-center justify-center p-4 cursor-pointer h-full text-gray-500 dark:text-white"
+          data-test-mox-card-menu
+        >
+          {{yield to="menu"}}
+        </div>
+      {{/if}}
+    </div>
 
   </div>
 </article>

--- a/addon/components/mox/card/aside.hbs
+++ b/addon/components/mox/card/aside.hbs
@@ -1,0 +1,23 @@
+{{#if @route}}
+  <Mox::Link
+    @route={{@route}}
+    @model={{@model}}
+    class="flex items-center justify-end p-4 gap-x-4 cursor-pointer"
+    data-test-mox-card-aside-link
+  >
+
+    {{yield}}
+
+  </Mox::Link>
+{{else}}
+  <button
+    type="button"
+    class="flex items-center justify-end p-4 gap-x-4 cursor-pointer"
+    {{on "click" this.onClick}}
+    data-test-mox-card-aside-button
+  >
+
+    {{yield}}
+
+  </button>
+{{/if}}

--- a/addon/components/mox/card/aside.js
+++ b/addon/components/mox/card/aside.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { isPresent } from '@ember/utils';
+
+export default class MoxCardAsideComponent extends Component {
+  @action
+  onClick() {
+    if (isPresent(this.args.onClick)) {
+      this.args.onClick();
+    }
+  }
+}

--- a/addon/components/mox/card/main.hbs
+++ b/addon/components/mox/card/main.hbs
@@ -2,7 +2,7 @@
   <Mox::Link
     @route={{@route}}
     @model={{@model}}
-    class="flex w-11/12 items-center justify-start p-4 gap-x-4 cursor-pointer"
+    class="flex flex-1 items-center justify-start p-4 gap-x-4 cursor-pointer overflow-hidden truncate"
     data-test-mox-card-link
   >
 
@@ -12,7 +12,7 @@
 {{else}}
   <button
     type="button"
-    class="flex w-11/12 items-center justify-start p-4 gap-x-4 cursor-pointer"
+    class="flex flex-1 items-center justify-start p-4 gap-x-4 cursor-pointer overflow-hidden truncate"
     {{on "click" this.onClick}}
     data-test-mox-card-button
   >

--- a/app/components/mox/article.js
+++ b/app/components/mox/article.js
@@ -1,0 +1,1 @@
+export { default } from 'mx-ui-components/components/mox/article';

--- a/app/components/mox/article/header.js
+++ b/app/components/mox/article/header.js
@@ -1,0 +1,1 @@
+export { default } from 'mx-ui-components/components/mox/article/header';

--- a/app/components/mox/card/aside.js
+++ b/app/components/mox/card/aside.js
@@ -1,0 +1,1 @@
+export { default } from 'mx-ui-components/components/mox/card/aside';

--- a/stories/mox-article-light.stories.js
+++ b/stories/mox-article-light.stories.js
@@ -1,0 +1,77 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Mox Light/Mox::Article',
+  argTypes: {
+    content: { control: 'text' },
+  },
+  parameters: {
+    backgrounds: {
+      default: 'Mute',
+      values: [
+        {
+          name: 'White',
+          value: '#ffffff',
+        },
+        {
+          name: 'Mute',
+          value: '#F3F4F6',
+        },
+      ],
+    },
+  },
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <Mox::Article>
+      {{this.content}}
+    </Mox::Article>`,
+  context: args,
+});
+
+const HeaderTemplate = (args) => ({
+  template: hbs`
+    <Mox::Article>
+      <Mox::Article::Header>
+        <:title>
+          {{this.title}}
+        </:title>
+        <:subtitle>
+          {{this.content}}
+        </:subtitle>
+      </Mox::Article::Header>
+    </Mox::Article>`,
+  context: args,
+});
+
+const AnotherHeaderTemplate = (args) => ({
+  template: hbs`
+    <Mox::Article>
+      <Mox::Article::Header>
+        {{this.title}}
+      </Mox::Article::Header>
+
+      {{this.content}}
+    </Mox::Article>`,
+  context: args,
+});
+
+
+export const Default = Template.bind({});
+Default.args = {
+  content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent condimentum pulvinar posuere. Quisque viverra ante ut risus auctor ullamcorper. Integer cursus quis ex in ultrices. Phasellus mollis risus massa, eu mattis dui laoreet sed. Pellentesque vel mi sagittis, porta purus vel, vulputate dolor. Donec eget nulla libero. Aenean mi ante, elementum nec blandit ut, luctus id odio. Nunc venenatis, nulla sed sodales ultricies, mauris sapien aliquam leo, bibendum aliquet dui arcu at orci. Nam lacinia, risus condimentum scelerisque pretium, lectus urna pellentesque nulla, eu rhoncus neque arcu ac metus. Nunc vel lacinia quam, sed vehicula nulla. Nunc vel cursus nibh, et pharetra sapien. Interdum et malesuada fames ac ante ipsum primis in faucibus.`,
+};
+
+export const WithFullHeader = HeaderTemplate.bind({});
+WithFullHeader.args = {
+  content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent condimentum pulvinar posuere.`,
+  title: 'Integrations',
+};
+
+export const WithSimpleHeader = AnotherHeaderTemplate.bind({});
+WithSimpleHeader.args = {
+  content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent condimentum pulvinar posuere. Quisque viverra ante ut risus auctor ullamcorper. Integer cursus quis ex in ultrices. Phasellus mollis risus massa, eu mattis dui laoreet sed. Pellentesque vel mi sagittis, porta purus vel, vulputate dolor. Donec eget nulla libero. Aenean mi ante, elementum nec blandit ut, luctus id odio. Nunc venenatis, nulla sed sodales ultricies, mauris sapien aliquam leo, bibendum aliquet dui arcu at orci. Nam lacinia, risus condimentum scelerisque pretium, lectus urna pellentesque nulla, eu rhoncus neque arcu ac metus. Nunc vel lacinia quam, sed vehicula nulla. Nunc vel cursus nibh, et pharetra sapien. Interdum et malesuada fames ac ante ipsum primis in faucibus.`,
+  title: 'Integrations',
+};
+

--- a/stories/mox-article.stories.js
+++ b/stories/mox-article.stories.js
@@ -1,0 +1,93 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Mox Dark/Mox::Article',
+  argTypes: {
+    content: { control: 'text' },
+    title: { control: 'text' },
+  },
+  parameters: {
+    backgrounds: {
+      default: 'Dark',
+      values: [
+        {
+          name: 'Dark',
+          value: '#111827',
+        },
+        {
+          name: 'Sky',
+          value: '#06B6D4',
+        },
+      ],
+    },
+  },
+};
+
+const Template = (args) => ({
+  template: hbs`
+  <div class="dark">
+    <Mox::Article>
+      {{this.content}}
+    </Mox::Article>
+  </div>`,
+  context: args,
+  parameters: {
+    background: 'Dark',
+  },
+});
+
+const HeaderTemplate = (args) => ({
+  template: hbs`
+  <div class="dark">
+    <Mox::Article>
+      <Mox::Article::Header>
+        <:title>
+          {{this.title}}
+        </:title>
+        <:subtitle>
+          {{this.content}}
+        </:subtitle>
+      </Mox::Article::Header>
+    </Mox::Article>
+  </div>`,
+  context: args,
+  parameters: {
+    background: 'Dark',
+  },
+});
+
+const AnotherHeaderTemplate = (args) => ({
+  template: hbs`
+  <div class="dark">
+    <Mox::Article>
+      <Mox::Article::Header>
+        {{this.title}}
+      </Mox::Article::Header>
+
+      {{this.content}}
+    </Mox::Article>
+  </div>`,
+  context: args,
+  parameters: {
+    background: 'Dark',
+  },
+});
+
+
+export const Default = Template.bind({});
+Default.args = {
+  content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent condimentum pulvinar posuere. Quisque viverra ante ut risus auctor ullamcorper. Integer cursus quis ex in ultrices. Phasellus mollis risus massa, eu mattis dui laoreet sed. Pellentesque vel mi sagittis, porta purus vel, vulputate dolor. Donec eget nulla libero. Aenean mi ante, elementum nec blandit ut, luctus id odio. Nunc venenatis, nulla sed sodales ultricies, mauris sapien aliquam leo, bibendum aliquet dui arcu at orci. Nam lacinia, risus condimentum scelerisque pretium, lectus urna pellentesque nulla, eu rhoncus neque arcu ac metus. Nunc vel lacinia quam, sed vehicula nulla. Nunc vel cursus nibh, et pharetra sapien. Interdum et malesuada fames ac ante ipsum primis in faucibus.`,
+};
+
+export const WithFullHeader = HeaderTemplate.bind({});
+WithFullHeader.args = {
+  content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent condimentum pulvinar posuere.`,
+  title: 'Integrations',
+};
+
+export const WithSimpleHeader = AnotherHeaderTemplate.bind({});
+WithSimpleHeader.args = {
+  content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent condimentum pulvinar posuere. Quisque viverra ante ut risus auctor ullamcorper. Integer cursus quis ex in ultrices. Phasellus mollis risus massa, eu mattis dui laoreet sed. Pellentesque vel mi sagittis, porta purus vel, vulputate dolor. Donec eget nulla libero. Aenean mi ante, elementum nec blandit ut, luctus id odio. Nunc venenatis, nulla sed sodales ultricies, mauris sapien aliquam leo, bibendum aliquet dui arcu at orci. Nam lacinia, risus condimentum scelerisque pretium, lectus urna pellentesque nulla, eu rhoncus neque arcu ac metus. Nunc vel lacinia quam, sed vehicula nulla. Nunc vel cursus nibh, et pharetra sapien. Interdum et malesuada fames ac ante ipsum primis in faucibus.`,
+  title: 'Integrations',
+};
+

--- a/stories/mox-card-light.stories.js
+++ b/stories/mox-card-light.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Mox Dark/Mox::Card',
+  title: 'Mox Light/Mox::Card',
   argTypes: {
     title: { control: 'text' },
     subtitle: { control: 'text' },
@@ -13,15 +13,15 @@ export default {
   },
   parameters: {
     backgrounds: {
-      default: 'Dark',
+      default: 'Mute',
       values: [
         {
-          name: 'Dark',
-          value: '#111827',
+          name: 'White',
+          value: '#ffffff',
         },
         {
-          name: 'Sky',
-          value: '#06B6D4',
+          name: 'Mute',
+          value: '#F3F4F6',
         },
       ],
     },
@@ -30,27 +30,24 @@ export default {
 
 const Template = (args) => ({
   template: hbs`
-  <div class="dark">
-    <div class="flex flex-col space-y-4 box-border w-container">
-      <Mox::Card>
-        <:title>
-          {{this.title}}
-        </:title>
-        <:subtitle>
-          {{this.subtitle}}
-        </:subtitle>
-      </Mox::Card>
-    </div>
+  <div class="flex flex-col space-y-4 box-border w-container">
+    <Mox::Card>
+      <:title>
+        {{this.title}}
+      </:title>
+      <:subtitle>
+        {{this.subtitle}}
+      </:subtitle>
+    </Mox::Card>
   </div>`,
   context: args,
   parameters: {
-    background: 'Dark',
+    background: 'Mute',
   },
 });
 
 const IconTemplate = (args) => ({
   template: hbs`
-  <div class="dark">
     <div class="flex flex-col space-y-4 box-border w-container">
       <Mox::Card>
         <:icon>
@@ -58,11 +55,13 @@ const IconTemplate = (args) => ({
         </:icon>
         <:title>
           <span>{{this.title}}</span>
-          <Mox::Badge @status="healthy">Running</Mox::Badge>
         </:title>
         <:subtitle>
           {{this.subtitle}}
         </:subtitle>
+        <:details>
+          {{this.details}}
+        </:details>
         <:menu>
           <button type="button">
             <Mox::Icon @iconName="action-menu-16" />
@@ -70,14 +69,12 @@ const IconTemplate = (args) => ({
         </:menu>
       </Mox::Card>
     </div>
-  </div>
   `,
   context: args,
 });
 
 const LogoTemplate = (args) => ({
   template: hbs`
-  <div class="dark">
     <div class="flex flex-col space-y-4 box-border w-container">
       <Mox::Card>
         <:icon>
@@ -96,7 +93,6 @@ const LogoTemplate = (args) => ({
         </:menu>
       </Mox::Card>
     </div>
-  </div>
   `,
   context: args,
 });
@@ -104,17 +100,18 @@ const LogoTemplate = (args) => ({
 export const WithIcon = IconTemplate.bind({});
 WithIcon.args = {
   title: 'ecom-search-update',
-  subtitle: 'JavaScript · Turbine Application · Deployed to Common · Feb 23',
+  subtitle: 'Running on production',
   idd: 'ecom',
   icon: 'connectors-16',
   logo: null,
   buttonType: null,
   small: false,
+  details: 'Last deployed from main 1 week ago by anonymous',
 };
 
 export const WithLogo = LogoTemplate.bind({});
 WithLogo.args = {
-  title: 'ecom-search-update-but-with-a-veryveryveryveryveryvery-elaborate-text',
+  title: 'ecom-search-update-but-with-a-veryveryveryveryveryveryextremely-elaborate-text',
   subtitle: 'JavaScript · Turbine Application · Deployed to Common · Feb 23',
   idd: 'ecom',
   icon: null,

--- a/tests/integration/components/mox/article-test.js
+++ b/tests/integration/components/mox/article-test.js
@@ -1,0 +1,85 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Integration | Component | mox/article', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <Mox::Article>
+        rotersand
+      </Mox::Article>
+    `);
+
+    assert.dom('[data-test-mox-article]').hasText('rotersand');
+  });
+
+  test('it renders in dark mode', async function (assert) {
+    await render(hbs`
+    <div class="dark bg-gray-900 p-4">
+      <Mox::Article>
+        <Mox::Article::Header>
+          <:title>
+            deine lakeien
+          </:title>
+          <:subtitle>
+            dark star
+          </:subtitle>
+        </Mox::Article::Header>
+      </Mox::Article>
+    </div>
+    `);
+
+    assert.dom('[data-test-mox-article]').hasStyle({ backgroundColor: 'rgb(31, 41, 55)' });
+    assert.dom('[data-test-mox-article]').hasStyle({ color: 'rgb(255, 255, 255)' });
+    assert.dom('[data-test-mox-article-header-title]').hasStyle({ color: 'rgb(255, 255, 255)' });
+    assert.dom('[data-test-mox-article-header-subtitle]').hasStyle({ color: 'rgb(209, 213, 219)' });
+  });
+
+  test('it renders in light mode', async function (assert) {
+    await render(hbs`
+      <Mox::Article>
+        <Mox::Article::Header>
+          <:title>
+            deine lakeien
+          </:title>
+          <:subtitle>
+            dark star
+          </:subtitle>
+        </Mox::Article::Header>
+      </Mox::Article>
+    `);
+
+    assert.dom('[data-test-mox-article]').hasStyle({ backgroundColor: 'rgb(255, 255, 255)' });
+    assert.dom('[data-test-mox-article]').hasStyle({ color: 'rgb(55, 65, 81)' });
+    assert.dom('[data-test-mox-article-header-title]').hasStyle({ color: 'rgb(31, 41, 55)' });
+    assert.dom('[data-test-mox-article-header-subtitle]').hasStyle({ color: 'rgb(55, 65, 81)' });
+  });
+
+  test('it is accessible (light mode)', async function (assert) {
+    await render(hbs`
+      <Mox::Article>
+        rotersand
+      </Mox::Article>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y errors');
+  });
+
+  test('it is accessible (dark mode)', async function (assert) {
+    await render(hbs`
+    <div class="dark bg-gray-900 p-4">
+      <Mox::Article>
+          rotersand
+        </Mox::Article>
+      </div>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y errors');
+  });
+});

--- a/tests/integration/components/mox/article/header-test.js
+++ b/tests/integration/components/mox/article/header-test.js
@@ -1,0 +1,73 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Integration | Component | mox/article/header', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders (default)', async function (assert) {
+    await render(hbs`
+      <Mox::Article::Header>
+        deine lakeien
+      </Mox::Article::Header>
+    `);
+
+    assert.dom('[data-test-mox-article-header-title]').hasText('deine lakeien');
+    assert.dom('[data-test-mox-article-header-title]').hasTagName('h2');
+  });
+
+  test('it renders (title + subtitle)', async function (assert) {
+    await render(hbs`
+      <Mox::Article::Header>
+        <:title>
+          deine lakeien
+        </:title>
+        <:subtitle>
+          dark star
+        </:subtitle>
+      </Mox::Article::Header>
+    `);
+
+    assert.dom('[data-test-mox-article-header-title]').hasText('deine lakeien');
+    assert.dom('[data-test-mox-article-header-title]').hasTagName('h2');
+    assert.dom('[data-test-mox-article-header-subtitle]').hasText('dark star');
+    assert.dom('[data-test-mox-article-header-subtitle]').hasTagName('p');
+  });
+
+
+  test('it is accessible (light mode)', async function (assert) {
+    await render(hbs`
+      <Mox::Article::Header>
+        <:title>
+          deine lakeien
+        </:title>
+        <:subtitle>
+          dark star
+        </:subtitle>
+      </Mox::Article::Header>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y errors');
+  });
+
+  test('it is accessible (dark mode)', async function (assert) {
+    await render(hbs`
+      <div class="dark bg-gray-900 p-4">
+        <Mox::Article::Header>
+          <:title>
+            deine lakeien
+          </:title>
+          <:subtitle>
+            dark star
+          </:subtitle>
+        </Mox::Article::Header>
+      </div>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y errors');
+  });
+});

--- a/tests/integration/components/mox/card-test.js
+++ b/tests/integration/components/mox/card-test.js
@@ -136,4 +136,22 @@ module('Integration | Component | mox/card', function (hooks) {
     await a11yAudit();
     assert.ok(true, 'no a11y detected');
   });
+
+  test('it has no accessibility issues (dark mode)', async function (assert) {
+    await render(hbs`
+    <div class="dark bg-gray-900 p-4">
+      <Mox::Card @route="application">
+        <:title>
+          FFVII
+        </:title>
+        <:subtitle>
+          PS1 · RPG · 1994
+        </:subtitle>
+      </Mox::Card>
+    </div>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y detected');
+  });
 });

--- a/tests/integration/components/mox/card/aside-test.js
+++ b/tests/integration/components/mox/card/aside-test.js
@@ -1,0 +1,82 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+
+module('Integration | Component | mox/card/aside', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the block', async function (assert) {
+    await render(hbs`
+      <Mox::Card::Aside>
+        template block text
+      </Mox::Card::Aside>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+
+  test('it renders the link element if a route is passed', async function (assert) {
+    await render(hbs`
+      <Mox::Card::Aside @route="application">
+        template block text
+      </Mox::Card::Aside>
+    `);
+
+    assert.dom('[data-test-mox-card-aside-link]').exists();
+    assert.dom('[data-test-mox-card-aside-button]').doesNotExist();
+    assert.dom('[data-test-mox-card-aside-link]').hasText('template block text');
+  });
+
+  test('it renders the button element if no route is passed', async function (assert) {
+    await render(hbs`
+      <Mox::Card::Aside>
+        template block text
+      </Mox::Card::Aside>
+    `);
+
+    assert.dom('[data-test-mox-card-aside-button]').exists();
+    assert.dom('[data-test-mox-card-aside-link]').doesNotExist();
+    assert.dom('[data-test-mox-card-aside-button]').hasText('template block text');
+  });
+
+  test('it triggers the @onClick action when clicked', async function (assert) {
+    assert.expect(1);
+
+    this.set('dummyAction', () => {
+      assert.ok(true, 'it triggers the onClick action');
+    });
+
+    await render(hbs`
+      <Mox::Card::Aside @onClick={{this.dummyAction}}>
+        template block text
+      </Mox::Card::Aside>
+    `);
+
+    await click('[data-test-mox-card-aside-button]');
+  });
+
+  test('it has no accessibility issues (button mode)', async function (assert) {
+    await render(hbs`
+      <Mox::Card::Aside>
+        template block text
+      </Mox::Card::Aside>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y detected');
+  });
+
+  test('it has no accessibility issues (link mode)', async function (assert) {
+    await render(hbs`
+      <Mox::Card::Aside @route="application">
+        template block text
+      </Mox::Card::Aside>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y detected');
+  });
+});


### PR DESCRIPTION
Closes https://github.com/meroxa/platform-ui-v1/issues/989

With this change, we're updating the UI for `Mox::Card` as part of [the redesign](https://github.com/meroxa/product/issues/832) and [app settings work](https://github.com/meroxa/product/issues/875). This also adds the following new components to the library:

### Mox::Article::Header

```html
<Mox::Article::Header>
  <:title>
    Grandia
  </:title>
  <:subtitle>
    category: videogames
  </:subtitle>
</Mox::Article::Header>
```

### Mox::Article

```html
<Mox::Article>
   Baphomet's Curse
</Mox::Article>
```

## Screens

### Mox::Card 

| dark mode | light mode |
|--|--|
|![Screenshot 2023-07-07 at 1 20 02 PM](https://github.com/ConduitIO/mx-ui-components/assets/8811742/113fd97b-4673-44db-8201-d88201592e28)|![Screenshot 2023-07-07 at 1 20 17 PM](https://github.com/ConduitIO/mx-ui-components/assets/8811742/d978ba38-397f-4489-9ec7-156ab4bfe336)|

### Mox::Article (+ Mox::Article::Header)

| dark mode | light mode |
|--|--|
|![Screenshot 2023-07-07 at 1 21 02 PM](https://github.com/ConduitIO/mx-ui-components/assets/8811742/76bc51f1-0ef3-441e-b5e1-c71f4d230326)|![Screenshot 2023-07-07 at 1 21 30 PM](https://github.com/ConduitIO/mx-ui-components/assets/8811742/ff8b2664-b599-4082-800f-a72b823aabd6)|