### PR TITLE
upd(mox:input): update light mode UI for input fields

### DIFF
--- a/.changeset/wise-pears-work.md
+++ b/.changeset/wise-pears-work.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": patch
+---
+
+upd(mox:input): update light mode UI for input fields + links

--- a/addon/components/mox/input.hbs
+++ b/addon/components/mox/input.hbs
@@ -6,10 +6,10 @@
   type="text"
   class="px-4 py-2 w-full text-gray-800 dark:text-white text-sm rounded bg-white dark:bg-gray-800
     read-only:text-gray-800 dark:read-only:text-white disabled:text-gray-600 dark:disabled:text-gray-500
-    disabled:bg-gray-200 read-only:bg-gray-200 disabled:border-gray-200 read-only:border-gray-200
+    disabled:bg-gray-200 read-only:bg-gray-50 disabled:border-gray-200 read-only:border-gray-400
     dark:disabled:bg-gray-700 dark:read-only:bg-gray-700 dark:disabled:border-gray-700 dark:read-only:border-gray-700 disabled:cursor-not-allowed
     read-only:focus:border-cyan-500 dark:read-only:focus:border-white dark:ready-only:focus:ring-white
-    {{if this.isValid 'border-gray-100 dark:border-gray-500 focus:border-cyan-500 focus:ring-cyan-500'
+    {{if this.isValid 'border-gray-400 dark:border-gray-500 focus:border-cyan-500 focus:ring-cyan-500'
     'border-red-500 dark:border-red-800 active:border-red-500 dark:active:border-red-900 focus:border-red-500 dark:focus:border-red-900 focus:ring-red-500 dark:focus:ring-red-900'}}"
   value={{@value}}
   placeholder={{@placeholder}}

--- a/addon/components/mox/link.hbs
+++ b/addon/components/mox/link.hbs
@@ -7,7 +7,7 @@
       "mxa-btn border block text-white border-cyan-700 bg-cyan-700
         active:bg-cyan-800 hover:border-cyan-600 hover:bg-cyan-600
         focus:outline-none focus:ring-1 focus:ring-white focus:border-white focus:bg-cyan-600"
-      "font-medium text-sm text-cyan-500 hover:dark:text-white transition duration-300"
+      "font-medium text-sm text-cyan-700 dark:text-cyan-500 hover:text-cyan-500 focus:text-cyan-500 hover:dark:text-white focus:dark:text-white transition duration-300"
     }}
     data-test-mox-link={{@route}}
     ...attributes
@@ -23,7 +23,7 @@
       "mxa-btn border block text-white border-cyan-700 bg-cyan-700
         active:bg-cyan-800 hover:border-cyan-600 hover:bg-cyan-600
         focus:outline-none focus:ring-1 focus:ring-white focus:border-white focus:bg-cyan-600"
-      "font-medium text-sm text-cyan-500 hover:dark:text-white transition"
+      "font-medium text-sm text-cyan-700 dark:text-cyan-500 hover:text-cyan-500 focus:text-cyan-500 hover:dark:text-white focus:dark:text-white transition duration-300"
     }}
     data-test-mox-link
     rel="noopener noreferrer"

--- a/tests/integration/components/mox/input-test.js
+++ b/tests/integration/components/mox/input-test.js
@@ -103,8 +103,8 @@ module('Integration | Component | mox/input', function (hooks) {
       await render(hbs`<Mox::Input @onInput={{this.onInput}} readonly />`);
 
       assert.dom('[data-test-mox-input]').hasStyle({
-        borderColor: 'rgb(229, 231, 235)',
-        backgroundColor: 'rgb(229, 231, 235)',
+        borderColor: 'rgb(156, 163, 175)',
+        backgroundColor: 'rgb(249, 250, 251)',
         color: 'rgb(31, 41, 55)',
       });
     });
@@ -119,7 +119,7 @@ module('Integration | Component | mox/input', function (hooks) {
 
       assert.dom('[data-test-mox-input]').doesNotHaveClass('border-red-500');
       assert.dom('[data-test-mox-input]').hasStyle({
-        borderColor: 'rgb(243, 244, 246)',
+        borderColor: 'rgb(156, 163, 175)',
       });
 
       this.set('isValid', false);
@@ -133,7 +133,7 @@ module('Integration | Component | mox/input', function (hooks) {
 
       assert.dom('[data-test-mox-input]').doesNotHaveClass('border-red-500');
       assert.dom('[data-test-mox-input]').hasStyle({
-        borderColor: 'rgb(243, 244, 246)',
+        borderColor: 'rgb(156, 163, 175)',
       });
     });
 
@@ -165,6 +165,17 @@ module('Integration | Component | mox/input', function (hooks) {
       await render(
         hbs`<div class="bg-gray-50"><Mox::Input @onInput={{this.onInput}} @label="Address" @id="address-field" @isValid={{false}} @error="Missing something?" /></div>`
       );
+      await a11yAudit();
+      assert.ok(true, 'no accessibility errors');
+    });
+
+    test('the default state is accessible', async function (assert) {
+      this.set('onInput', () => {});
+
+      await render(
+        hbs`<div class="bg-gray-50 p-4"><Mox::Input @onInput={{this.onInput}} @label="Address" @id="address-field" /></div>`
+      );
+
       await a11yAudit();
       assert.ok(true, 'no accessibility errors');
     });
@@ -265,6 +276,17 @@ module('Integration | Component | mox/input', function (hooks) {
       await render(
         hbs`<div class="bg-gray-900 dark p-4"><Mox::Input @onInput={{this.onInput}} @label="Address" @id="address-field" @isValid={{false}} @error="Missing something?" /></div>`
       );
+      await a11yAudit();
+      assert.ok(true, 'no accessibility errors');
+    });
+
+    test('the default state is accessible', async function (assert) {
+      this.set('onInput', () => {});
+
+      await render(
+        hbs`<div class="bg-gray-900 p-4 dark"><Mox::Input @onInput={{this.onInput}} @label="Address" @id="address-field" /></div>`
+      );
+
       await a11yAudit();
       assert.ok(true, 'no accessibility errors');
     });

--- a/tests/integration/components/mox/link-test.js
+++ b/tests/integration/components/mox/link-test.js
@@ -64,9 +64,9 @@ module('Integration | Component | mox/link', function (hooks) {
     assert.dom('[data-test-mox-link]').hasClass('bg-cyan-700');
   });
 
-  test('it is accessible (@route)', async function (assert) {
+  test('it is accessible (@route + dark mode)', async function (assert) {
     await render(hbs`
-      <div class="bg-gray-900">
+      <div class="bg-gray-900 dark">
         <Mox::Link @route="application">
           Internal link
         </Mox::Link>
@@ -77,9 +77,35 @@ module('Integration | Component | mox/link', function (hooks) {
     assert.ok(true, 'no a11y errors detected');
   });
 
-  test('it is accessible (@externalUrl)', async function (assert) {
+  test('it is accessible (@route + light mode)', async function (assert) {
     await render(hbs`
-      <div class="bg-gray-900">
+      <div class="bg-gray-50">
+        <Mox::Link @route="application">
+          Internal link
+        </Mox::Link>
+      </div>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y errors detected');
+  });
+
+  test('it is accessible (@externalUrl + dark mode)', async function (assert) {
+    await render(hbs`
+      <div class="bg-gray-900 dark">
+        <Mox::Link @externalUrl="http://localhost:7357">
+          External link
+        </Mox::Link>
+      </div>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y errors detected');
+  });
+
+  test('it is accessible (@externalUrl + light mode)', async function (assert) {
+    await render(hbs`
+      <div class="bg-gray-50">
         <Mox::Link @externalUrl="http://localhost:7357">
           External link
         </Mox::Link>


### PR DESCRIPTION
Part of https://github.com/meroxa/platform-ui-v1/issues/1029

This reduces the brightness of some colors used within the `Mox::Input` component and `Mox::Link`  in order to improve the elements' contrast on light backgrounds. This way, we can write automated accessibility tests for the work of https://github.com/meroxa/auth0-templates/issues/210

## Screens

### Input Fields

| light mode |  dark mode |
|--|--|
|![input-light-mode](https://github.com/ConduitIO/mx-ui-components/assets/8811742/16435bb0-09fb-4112-8c87-d36b7ff4bb2e)|![input-dark-mode](https://github.com/ConduitIO/mx-ui-components/assets/8811742/328dd1f6-ae78-48c9-acda-7a2ad2da24b2)|

### Links

| light mode | dark mode |
|--|--|
|![Screenshot 2023-07-21 at 1 13 06 PM](https://github.com/ConduitIO/mx-ui-components/assets/8811742/d517f630-2168-4c28-adbc-725001c5d863)|![Screenshot 2023-07-21 at 1 13 18 PM](https://github.com/ConduitIO/mx-ui-components/assets/8811742/db66d3e2-c590-4bd3-a1bf-a85387f67958)|