### PR TITLE
fix(mox): fix layout + alignment of mox:input + mox:theme-switch comp

### DIFF
--- a/.changeset/kind-beans-refuse.md
+++ b/.changeset/kind-beans-refuse.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": patch
+---
+
+fix(mox): fix layout + alignment of mox:input + mox:theme-switch comp

--- a/addon/components/mox/input.hbs
+++ b/addon/components/mox/input.hbs
@@ -1,7 +1,7 @@
 {{#if @label}}
   <Mox::Label for={{@id}} @isRequired={{@isRequired}}>{{@label}}</Mox::Label>
 {{/if}}
-<div class="flex flex-col justify-center space-y-1">
+<div class="flex flex-col justify-center space-y-1 w-full">
   <input
     id={{@id}}
     type="text"

--- a/addon/styles/mx-ui-components.css
+++ b/addon/styles/mx-ui-components.css
@@ -87,7 +87,6 @@
 .mox-theme-switch input:checked::after,
 .mox-theme-switch-icon.is-checked {
   transform: translateX(15px);
-  background-color: #fff;
 }
 
 .mox-theme-switch input:checked::after {

--- a/stories/mox-input-light.stories.js
+++ b/stories/mox-input-light.stories.js
@@ -22,19 +22,21 @@ export default {
 
 const Template = (args) => ({
   template: hbs`
+  <div class="w-48">
   <Mox::Input
     @value={{this.value}} @onInput={{this.inputAction}}
     @placeholder={{this.placeholder}} @label={{this.label}}
     disabled={{this.isDisabled}} @isRequired={{this.isRequired}}
     readonly={{this.readOnly}}
     @isValid={{this.isValid}} @error={{this.error}} />
+  </div>
   `,
   context: args,
 });
 
 const TemplateStackedFormFields = (args) => ({
   template: hbs`
-  <div class="flex flex-col">
+  <div class="flex flex-col w-48">
     <Mox::Input
       @value={{this.value}} @onInput={{this.inputAction}}
       @placeholder={{this.placeholder}} @label={{this.label}}

--- a/stories/mox-input.stories.js
+++ b/stories/mox-input.stories.js
@@ -12,7 +12,7 @@ export default {
 
 const Template = (args) => ({
   template: hbs`
-  <div class="dark">
+  <div class="dark w-48">
   <Mox::Input
     @value={{this.value}} @onInput={{this.inputAction}}
     @placeholder={{this.placeholder}} @label={{this.label}}
@@ -25,7 +25,7 @@ const Template = (args) => ({
 
 const TemplateStackedFormFields = (args) => ({
   template: hbs`
-  <div class="dark flex flex-col">
+  <div class="dark flex flex-col w-48">
     <Mox::Input
       @value={{this.value}} @onInput={{this.inputAction}}
       @placeholder={{this.placeholder}} @label={{this.label}}


### PR DESCRIPTION
Follow-up to https://github.com/meroxa/platform-ui-v1/issues/1029

This applies UI fixes to the `Mox::Input` and `Mox:ThemeSwitch` components.

## Screens

### `Mox::Input`

| before | after |
|--|--|
|![Screenshot 2023-07-26 at 6 18 18 PM](https://github.com/ConduitIO/mx-ui-components/assets/8811742/7fd3a7dc-6cde-4a5f-9540-da9f92a9902a)|![Screenshot 2023-07-26 at 6 11 01 PM](https://github.com/ConduitIO/mx-ui-components/assets/8811742/41cbd05a-c0a1-4a6c-a9d6-e98c01f7b48e)|

### `Mox::ThemeSwitch`

| before | after |
|--|--|
|![Screenshot 2023-07-26 at 6 18 23 PM](https://github.com/ConduitIO/mx-ui-components/assets/8811742/9de67d58-ff3c-470a-8af2-df9b835eb0b5)|![Screenshot 2023-07-26 at 6 10 47 PM](https://github.com/ConduitIO/mx-ui-components/assets/8811742/db417044-1ff1-46b7-abf8-e467bd50583e)|