### PR TITLE
feat: add light theme for modal components

### DIFF
--- a/.changeset/early-dots-end.md
+++ b/.changeset/early-dots-end.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": minor
+---
+
+feat: add light theme for modal components

--- a/addon/components/mox/modal-dialog.hbs
+++ b/addon/components/mox/modal-dialog.hbs
@@ -6,7 +6,11 @@
 >
   <:default as |titleId|>
     <div class="flex items-center justify-between mb-6">
-      <h1 id={{titleId}} class="text-white font-semibold text-2xl" data-test-modal-dialog-title>
+      <h1
+        id={{titleId}}
+        class="text-gray-800 dark:text-white font-semibold text-2xl"
+        data-test-modal-dialog-title
+      >
         {{yield to="title"}}
       </h1>
       <button
@@ -17,7 +21,7 @@
         {{focus-on-render}}
         data-test-modal-dialog-close
       >
-        <svg class="text-white fill-current h-4 w-4">
+        <svg class="dark:text-white fill-current h-4 w-4">
           <use xlink:href={{root-url "/svg-defs.svg#close-16"}}></use>
         </svg>
       </button>

--- a/addon/components/mox/modal.hbs
+++ b/addon/components/mox/modal.hbs
@@ -1,8 +1,11 @@
-<div class="fixed z-10 inset-0 overflow-y-auto text-white" data-test-modal>
+<div
+  class="fixed z-10 inset-0 overflow-y-auto text-gray-700 dark:text-white shadow-lg shadow-gray-800/20"
+  data-test-modal
+>
   <div
     class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
   >
-    {{!-- template-lint-disable no-invalid-interactive --}}
+    {{! template-lint-disable no-invalid-interactive }}
     <div
       class="fixed inset-0 transition-opacity"
       {{on "click" @onDismiss}}
@@ -11,13 +14,13 @@
     >
       <div class="absolute inset-0 bg-gray-800 opacity-90"></div>
     </div>
-    {{!-- template-lint-enable no-invalid-interactive --}}
+    {{! template-lint-enable no-invalid-interactive }}
 
     <span class="hidden sm:inline-block sm:align-middle sm:h-screen"></span>&#8203;
 
     <div
-      class="inline-block align-bottom bg-gray-900 rounded-md p-8 text-left overflow-visible transform transition-all w-container sm:my-8 sm:align-middle sm:max-w-3xl
-        {{if @isWide "sm:w-container" "sm:w-box"}}"
+      class="inline-block align-bottom bg-white dark:bg-gray-900 rounded-md p-8 text-left overflow-visible transform transition-all w-container sm:my-8 sm:align-middle sm:max-w-3xl
+        {{if @isWide 'sm:w-container' 'sm:w-box'}}"
       role="dialog"
       aria-modal="true"
       aria-labelledby={{this.titleId}}

--- a/stories/mox-confirm-modal-light.stories.js
+++ b/stories/mox-confirm-modal-light.stories.js
@@ -1,0 +1,63 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Mox Light/Mox::ConfirmModal',
+  parameters: {
+    backgrounds: {
+      default: 'Mute',
+      values: [
+        {
+          name: 'White',
+          value: '#ffffff',
+        },
+        {
+          name: 'Mute',
+          value: '#F3F4F6',
+        },
+      ],
+    },
+  },
+};
+
+const actionsData = {
+  destroyConnector: action('destroyConnector'),
+  hideDeleteConnectorModal: action('hideDeleteConnectorModal'),
+};
+
+const Template = (args) => ({
+  template: hbs`
+  <Mox::ConfirmModal
+    @onDismiss={{this.hideDeleteConnectorModal}}
+    @confirmableActionName={{this.confirmActionName}}
+    @entityName={{this.selectedNode.name}}
+    @confirmedAction={{fn this.destroyConnector this.selectedNode}}
+    @isTextInputRequired={{this.isInputTextRequired}}
+  >
+    {{this.modalText}}
+  </Mox::ConfirmModal>`,
+  context: args,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  isInputTextRequired: true,
+  confirmActionName: 'Delete',
+  modalText:
+    "Deleting a connector cannot be undone. Please input your connector's name below to confirm you would like to delete this connector",
+  selectedNode: {
+    name: 'foo',
+  },
+  ...actionsData,
+};
+
+export const SoftConfirm = Template.bind({});
+SoftConfirm.args = {
+  isInputTextRequired: false,
+  confirmActionName: 'Update',
+  modalText: 'Do you really want to update this?',
+  selectedNode: {
+    name: 'bar',
+  },
+  ...actionsData,
+};

--- a/stories/mox-modal-dialog-light.stories.js
+++ b/stories/mox-modal-dialog-light.stories.js
@@ -1,0 +1,56 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Mox Light/Mox::ModalDialog',
+  parameters: {
+    backgrounds: {
+      default: 'Mute',
+      values: [
+        {
+          name: 'White',
+          value: '#ffffff',
+        },
+        {
+          name: 'Mute',
+          value: '#F3F4F6',
+        },
+      ],
+    },
+  },
+};
+
+const actionsData = {
+  submit: action('destroyConnector'),
+  hideModal: action('hideDeleteConnectorModal'),
+};
+
+const Template = (args) => ({
+  template: hbs`
+  <Mox::ModalDialog @onDismiss={{this.hideModal}}>
+    <:title>
+      {{this.title}}
+    </:title>
+    <:body>
+      <p class="text-sm">Check them out in your team inbox!</p>
+    </:body>
+    <:footer as |footer|>
+      <footer.secondaryAction>Cancel</footer.secondaryAction>
+      <footer.primaryAction @onClick={{this.submit}}>Go to my inbox</footer.primaryAction>
+    </:footer>
+  </Mox::ModalDialog>`,
+  context: args,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  title: 'You got 2 new messages',
+  ...actionsData,
+};
+
+export const Wide = Template.bind({});
+Wide.args = {
+  title: 'You got 2 new messages',
+  isWide: true,
+  ...actionsData,
+};

--- a/stories/mox-modal-dialog.stories.js
+++ b/stories/mox-modal-dialog.stories.js
@@ -12,18 +12,21 @@ const actionsData = {
 
 const Template = (args) => ({
   template: hbs`
-  <Mox::ModalDialog @onDismiss={{this.hideModal}}>
-    <:title>
-      {{this.title}}
-    </:title>
-    <:body>
-      <p class="text-sm">Check them out in your team inbox!</p>
-    </:body>
-    <:footer as |footer|>
-      <footer.secondaryAction>Cancel</footer.secondaryAction>
-      <footer.primaryAction @onClick={{this.submit}}>Go to my inbox</footer.primaryAction>
-    </:footer>
-  </Mox::ModalDialog>`,
+  <div class="dark">
+    <Mox::ModalDialog @onDismiss={{this.hideModal}}>
+      <:title>
+        {{this.title}}
+      </:title>
+      <:body>
+        <p class="text-sm">Check them out in your team inbox!</p>
+      </:body>
+      <:footer as |footer|>
+        <footer.secondaryAction>Cancel</footer.secondaryAction>
+        <footer.primaryAction @onClick={{this.submit}}>Go to my inbox</footer.primaryAction>
+      </:footer>
+    </Mox::ModalDialog>
+  </div>
+  `,
   context: args,
 });
 

--- a/stories/mox-modal-light.stories.js
+++ b/stories/mox-modal-light.stories.js
@@ -1,0 +1,53 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Mox Light/Mox::Modal',
+  parameters: {
+    backgrounds: {
+      default: 'Mute',
+      values: [
+        {
+          name: 'White',
+          value: '#ffffff',
+        },
+        {
+          name: 'Mute',
+          value: '#F3F4F6',
+        },
+      ],
+    },
+  },
+};
+
+const actionsData = {
+  submit: action('destroyConnector'),
+  hideModal: action('hideDeleteConnectorModal'),
+};
+
+const Template = (args) => ({
+  template: hbs`
+  <Mox::Modal @onDismiss={{this.hideModal}}>
+    <:content as |content|>
+      <p class="text-sm">Check them out in your team inbox!</p>
+      <div class="mt-6">
+        <content.secondaryAction>Cancel</content.secondaryAction>
+        <content.primaryAction @onClick={{this.submit}}>Go to my inbox</content.primaryAction>
+      </div>
+    </:content>
+  </Mox::Modal>`,
+  context: args,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  title: 'You got 2 new messages',
+  ...actionsData,
+};
+
+export const Wide = Template.bind({});
+Wide.args = {
+  title: 'You got 2 new messages',
+  isWide: true,
+  ...actionsData,
+};

--- a/stories/mox-modal.stories.js
+++ b/stories/mox-modal.stories.js
@@ -12,15 +12,17 @@ const actionsData = {
 
 const Template = (args) => ({
   template: hbs`
-  <Mox::Modal @onDismiss={{this.hideModal}}>
-    <:content as |content|>
-      <p class="text-sm">Check them out in your team inbox!</p>
-      <div class="mt-6">
-        <content.secondaryAction>Cancel</content.secondaryAction>
-        <content.primaryAction @onClick={{this.submit}}>Go to my inbox</content.primaryAction>
-      </div>
-    </:content>
-  </Mox::Modal>`,
+  <div class="dark">
+    <Mox::Modal @onDismiss={{this.hideModal}}>
+      <:content as |content|>
+        <p class="text-sm">Check them out in your team inbox!</p>
+        <div class="mt-6">
+          <content.secondaryAction>Cancel</content.secondaryAction>
+          <content.primaryAction @onClick={{this.submit}}>Go to my inbox</content.primaryAction>
+        </div>
+      </:content>
+    </Mox::Modal>
+  </div>`,
   context: args,
 });
 

--- a/tests/integration/components/mox/confirm-modal-test.js
+++ b/tests/integration/components/mox/confirm-modal-test.js
@@ -65,6 +65,63 @@ module('Integration | Component | mox/confirm-modal', function (hooks) {
     });
   });
 
+  module('styling: light mode', function (hooks) {
+    hooks.beforeEach(async function () {
+      this.set('onDismiss', sinon.spy());
+      this.set('confirmedAction', sinon.spy());
+      this.set('confirmableActionName', 'Squanch');
+
+      await render(hbs`
+        <div class="p-4">
+          <Mox::ConfirmModal
+            @onDismiss={{this.onDismiss}}
+            @confirmableActionName={{this.confirmableActionName}}
+            @entityName='Plumbus'
+            @confirmedAction={{this.confirmedAction}}
+            @isTextInputRequired={{this.isTextInputRequired}}
+            as |entityName|
+          >
+            Are you sure you want to squanch {{entityName}}?
+          </Mox::ConfirmModal>
+        </div>
+      `);
+    });
+
+    module('when confirming', function (hooks) {
+      hooks.beforeEach(async function () {
+        this.set('isTextInputRequired', false);
+      });
+
+      test('it displays the default submit button (light mode)', async function (assert) {
+        assert
+          .dom('[data-test-confirm-submit-button]')
+          .hasClass('border-red-600');
+      });
+
+      test('it is accessible', async function (assert) {
+        await a11yAudit();
+        assert.ok(true, 'no a11y detected');
+      });
+    });
+
+    module('when text confirming', function (hooks) {
+      hooks.beforeEach(async function () {
+        this.set('isTextInputRequired', true);
+      });
+
+      test('it displays the danger submit button (light mode)', async function (assert) {
+        assert
+          .dom('[data-test-confirm-submit-button]')
+          .hasClass('border-red-600');
+      });
+
+      test('it is accessible', async function (assert) {
+        await a11yAudit();
+        assert.ok(true, 'no a11y detected');
+      });
+    });
+  });
+
   module('user interaction', function (hooks) {
     hooks.beforeEach(async function () {
       this.set('onDismiss', sinon.spy());

--- a/tests/integration/components/mox/modal-dialog-test.js
+++ b/tests/integration/components/mox/modal-dialog-test.js
@@ -1,4 +1,4 @@
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -184,7 +184,7 @@ module('Integration | Component | mox/modal-dialog', function (hooks) {
     assert.dom('[data-test-modal-dialog]').hasAttribute('aria-labelledby');
   });
 
-  skip('it is accessible (light mode)', async function (assert) {
+  test('it is accessible (light mode)', async function (assert) {
     await render(hbs`
       <Mox::ModalDialog @onDismiss={{this.dummyAction}}>
         <:title>

--- a/tests/integration/components/mox/modal-test.js
+++ b/tests/integration/components/mox/modal-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | mox/modal', function (hooks) {
   setupRenderingTest(hooks);
@@ -72,5 +73,41 @@ module('Integration | Component | mox/modal', function (hooks) {
     await click('[data-test-primary]');
     assert.ok(this.onDismiss.calledOnce);
     assert.ok(this.primaryAction.calledOnce);
+  });
+
+  test('it is accessible (dark mode)', async function (assert) {
+    this.set('onDismiss', sinon.spy());
+    await render(hbs`
+      <div class="dark">
+        <Mox::Modal @onDismiss={{this.onDismiss}}>
+          <:title>High Water</:title>
+          <:sub-title>By Sleep Token></:sub-title>
+          <:content as |c|>
+            <c.secondaryAction data-test-secondary>Go back</c.secondaryAction>
+            <c.primaryAction @onClick={{this.primaryAction}} data-test-primary>Listen</c.primaryAction>
+          </:content>
+        </Mox::Modal>
+      </div>
+    `);
+
+    await a11yAudit();
+    assert.ok(true);
+  });
+
+  test('it is accessible (light mode)', async function (assert) {
+    this.set('onDismiss', sinon.spy());
+    await render(hbs`
+      <Mox::Modal @onDismiss={{this.onDismiss}}>
+        <:title>High Water</:title>
+        <:sub-title>By Sleep Token></:sub-title>
+        <:content as |c|>
+          <c.secondaryAction data-test-secondary>Go back</c.secondaryAction>
+          <c.primaryAction @onClick={{this.primaryAction}} data-test-primary>Listen</c.primaryAction>
+        </:content>
+      </Mox::Modal>
+    `);
+
+    await a11yAudit();
+    assert.ok(true);
   });
 });


### PR DESCRIPTION
Updates Mox::Modal , Mox::ModalDialog, and Mox::ConfirmModal to all support light mode themes.

The following screenshot is of the light mode Mox::ConfirmModal, which uses all of the previously mentioned components.

<img width="687" alt="Screen Shot 2023-07-26 at 12 19 41 PM" src="https://github.com/ConduitIO/mx-ui-components/assets/4818826/42a8c8cd-9ae4-4efb-9a4d-8d1ae9350345">
