### PR TITLE
fix: add attributes to global header

### DIFF
--- a/.changeset/wicked-vans-wonder.md
+++ b/.changeset/wicked-vans-wonder.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": patch
+---
+
+fix: add attributes to global header

--- a/addon/components/mox/global-header.hbs
+++ b/addon/components/mox/global-header.hbs
@@ -1,4 +1,4 @@
-<header class="flex justify-between py-8" data-test-global-header>
+<header class="flex justify-between py-8" data-test-global-header ...attributes>
   <div class="flex items-center space-x-4">
     <a href="/" aria-label="Go to Homepage" data-test-global-header-logo>
       <svg


### PR DESCRIPTION
adds `...attributes` to the global header so we can pass down attributes