### PR TITLE
fix(mox:link): allow mox:link to accept query params

### DIFF
--- a/.changeset/unlucky-hats-look.md
+++ b/.changeset/unlucky-hats-look.md
@@ -1,0 +1,5 @@
+---
+"mx-ui-components": patch
+---
+
+fix(mox:link): allow mox:link to accept query params

--- a/addon/components/mox/link-to.hbs
+++ b/addon/components/mox/link-to.hbs
@@ -1,12 +1,24 @@
 {{#if @model}}
-  <LinkTo
-    @route={{@route}}
-    @model={{@model}}
-    data-test-mox-link={{@route}}
-    ...attributes
-  >
-    {{yield}}
-  </LinkTo>
+  {{#if @queryParams}}
+    <LinkTo
+      @route={{@route}}
+      @model={{@model}}
+      @query={{@queryParams}}
+      data-test-mox-link={{@route}}
+      ...attributes
+    >
+      {{yield}}
+    </LinkTo>
+  {{else}}
+    <LinkTo
+      @route={{@route}}
+      @model={{@model}}
+      data-test-mox-link={{@route}}
+      ...attributes
+    >
+      {{yield}}
+    </LinkTo>
+  {{/if}}
 {{else}}
   <LinkTo
     @route={{@route}}

--- a/addon/components/mox/link.hbs
+++ b/addon/components/mox/link.hbs
@@ -2,6 +2,7 @@
   <Mox::LinkTo
     @route={{@route}}
     @model={{@model}}
+    @queryParams={{@queryParams}}
     class={{if
       @isButton
       "mxa-btn border block text-white border-cyan-700 bg-cyan-700

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class ApplicationController extends Controller {}

--- a/tests/dummy/app/controllers/application/subroute.js
+++ b/tests/dummy/app/controllers/application/subroute.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default class SubRouteController extends Controller {
+  queryParams = ['filter'];
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,4 +6,6 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-Router.map(function () {});
+Router.map(function () {
+  this.route('subroute', { path: '/:model_id' });
+});

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ApplicationRoute extends Route {}

--- a/tests/dummy/app/routes/application/subroute.js
+++ b/tests/dummy/app/routes/application/subroute.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+
+export default class SubRouteRoute extends Route {
+  model(params) {
+    return {
+      id: params.model_id,
+      name: 'foo',
+    };
+  }
+}

--- a/tests/integration/components/mox/link-test.js
+++ b/tests/integration/components/mox/link-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, currentURL, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 
@@ -27,6 +27,34 @@ module('Integration | Component | mox/link', function (hooks) {
 
     assert.dom('[data-test-mox-link]').includesText('Internal link');
     assert.dom('[data-test-mox-link]').hasAttribute('href', '/');
+  });
+
+  test('it renders (@route + @model)', async function (assert) {
+    this.set('model', { id: 1 });
+    await render(hbs`
+      <Mox::Link @route="subroute" @model={{this.model}}>
+        Internal link
+      </Mox::Link>
+    `);
+
+    assert.dom('[data-test-mox-link]').includesText('Internal link');
+    assert.dom('[data-test-mox-link]').hasAttribute('href', '/1');
+  });
+
+  test('it renders (@route + @model + @queryParams)', async function (assert) {
+    this.set('model', { id: 1 });
+    await render(hbs`
+      <Mox::Link @route="subroute" @model={{this.model}} @queryParams={{hash filter="foo"}}>
+        Internal link
+      </Mox::Link>
+    `);
+
+    assert.dom('[data-test-mox-link]').includesText('Internal link');
+    assert.dom('[data-test-mox-link]').hasAttribute('href', '/1?filter=foo');
+
+    await click('[data-test-mox-link]');
+
+    assert.strictEqual(currentURL(), '/1');
   });
 
   test('it renders (@externalUrl)', async function (assert) {


### PR DESCRIPTION
Closes https://github.com/meroxa/platform-ui-v1/issues/1053

With this change, the `Mox::Link` component may now redirect to routes with query parameters, e.g. `/my-route?filter=foo`

